### PR TITLE
Update `Logger` type to be closer to winston's `Logger`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/node-winston",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/node-winston",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/node-winston",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": false,
   "description": "A set of winston formats, console transport and logger creation functions",
   "author": "MakerX",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { format, Format } from 'logform'
-import { createLogger as winstonCreateLogger, LoggerOptions, Logger as WinstonLogger } from 'winston'
+import { createLogger as winstonCreateLogger, Logger as WinstonLogger, LoggerOptions } from 'winston'
 import * as Transport from 'winston-transport'
 import { Console, ConsoleTransportOptions } from 'winston/lib/winston/transports'
 import { omitFormat } from './omit-format'
@@ -10,9 +10,19 @@ import { serializableErrorReplacer } from './serialize-error'
 export * from './omit-format'
 export * from './omit-nil-format'
 
-// Remove methods that are only available for syslog
-// See https://github.com/winstonjs/winston/blob/914b846846c5970711b5cba609dfbeb42c8580a7/index.d.ts#L142-L147
-export type Logger = Omit<WinstonLogger, 'emerg' | 'alert' | 'crit' | 'warning' | 'notice'>
+export type Logger = Pick<
+  WinstonLogger,
+  // Supports child loggers
+  | 'child'
+  // Common levels
+  | 'debug'
+  | 'error'
+  | 'info'
+  | 'verbose'
+  | 'warn'
+  // General log method
+  | 'log'
+>
 
 export interface CreateLoggerOptions {
   consoleFormat?: 'pretty' | 'json'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { format, Format } from 'logform'
-import { createLogger as winstonCreateLogger, LoggerOptions } from 'winston'
+import { createLogger as winstonCreateLogger, LoggerOptions, Logger as WinstonLogger } from 'winston'
 import * as Transport from 'winston-transport'
 import { Console, ConsoleTransportOptions } from 'winston/lib/winston/transports'
 import { omitFormat } from './omit-format'
@@ -10,14 +10,9 @@ import { serializableErrorReplacer } from './serialize-error'
 export * from './omit-format'
 export * from './omit-nil-format'
 
-export type Logger = {
-  child(options: Record<string, unknown>): Logger
-  error(message: string, ...optionalParams: unknown[]): void
-  warn(message: string, ...optionalParams: unknown[]): void
-  info(message: string, ...optionalParams: unknown[]): void
-  verbose(message: string, ...optionalParams: unknown[]): void
-  debug(message: string, ...optionalParams: unknown[]): void
-}
+// Remove methods that are only available for syslog
+// See https://github.com/winstonjs/winston/blob/914b846846c5970711b5cba609dfbeb42c8580a7/index.d.ts#L142-L147
+export type Logger = Omit<WinstonLogger, 'emerg' | 'alert' | 'crit' | 'warning' | 'notice'>
 
 export interface CreateLoggerOptions {
   consoleFormat?: 'pretty' | 'json'


### PR DESCRIPTION
## What

Update `Logger` type to be closer to winston's `Logger`.

## Why

After upgrading `@makerx/node-winston` in a project, I got a TypeScript error on the following code block, as `log` is not part of the definition.

```ts
const msalLoggerConfig: Partial<Configuration> = {
  system: {
    loggerOptions: {
      loggerCallback: (level, message) => logger.log(toNpmLogLevel(level), message),
    },
  },
}
```

I'm all for removing the methods that are not available in Node.js, but find the current definition too restrictive.
I'm not using [all the methods it defines](https://github.com/winstonjs/winston/blob/914b846846c5970711b5cba609dfbeb42c8580a7/index.d.ts#L109), but would like to be able to if I need to.

Was there a reason for restricting it to what it is now?