### PR TITLE
v2 beta - switch from lodash to es-toolkit and add features

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install @makerx/node-winston
 
 Breaking changes:
 
-- The `lodash` peer dependency has been replaced with `es-toolkit`. Install `es-toolkit` alongside winston (or it will be installed automatically).
+- The `lodash` dependency has been replaced with `es-toolkit` as a peer dependency.
 - `omitPaths` now applies at the logger level and affects every transport, not just the Console transport. If you added custom transports expecting the unredacted object, move omit/redact handling into that transport's format.
 - A new `audit` level sits between `warn` and `info`. Loggers configured at `level: 'info'` (or more verbose) will now include `audit` messages; loggers at `level: 'warn'` or higher still filter them out.
 - Pass a custom `levels` map via `loggerOptions` to opt out of the default level set (including `audit`); the returned logger type narrows to your keys.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Formats are applied in two layers:
 { error: 0, warn: 1, audit: 2, info: 3, debug: 4, verbose: 5 }
 ```
 
-Colours for the default levels (including `audit`) are registered at module load, so `colorize` / pretty output works out of the box.
+Colours for the default levels (including `audit`) are registered on the first `createLogger` call that uses them, so `colorize` / pretty output works out of the box.
 
 Pass your own `levels` via `loggerOptions` to override. When you do, the returned logger is typed against your level keys (so `logger.audit` is only present when the default levels are in use), and you should register colours for your levels via `winston.addColors`:
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ const logger = createLogger({
 `createLogger` applies some default behaviour, chaining `omitNilFormat` and `omitFormat` in front of the final json or coloured YAML format.
 
 - `omitNilFormat` removes null or undefined values from output
-- `omitFormat` removes values by path using [lodash omit](https://lodash.com/docs/4.17.15#omit) (see docs for path specification)
+- `omitFormat` removes values by path using [es-toolkit's compat omit](https://es-toolkit.dev/reference/compat/object/omit.html) (lodash-compatible, supports dot-notation paths)
 - `prettyConsoleFormat` applies the `colorize` and `timestamp` formats before formatting logs as coloured YAML
 
 If you wish to add additional formats, pass them in via the `consoleFormats` option.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,73 @@
 # Node Winston
 
-A set of [winston](https://github.com/winstonjs/winston) [formats](https://github.com/winstonjs/winston#formats), console transport and logger creation functions.
+A set of [winston](https://github.com/winstonjs/winston) [formats](https://github.com/winstonjs/winston#formats), a console transport and a logger factory that simplify structured logging in Node.js services — with colourised YAML output for local development.
 
-Simplifies using winston logging and provides coloured YAML log output for local development.
+## Installation
+
+```sh
+npm install @makerx/node-winston
+```
+
+`winston`, `logform`, `winston-transport`, `triple-beam` and `es-toolkit` are declared as peer dependencies, so bring your own versions (>=3, >=2, >=4, >=1, >=1 respectively).
 
 ## Creating a Logger
 
-The `createLogger` function combines `omitFormat`, `omitNilFormat` and optionally `prettyConsoleFormat` together to configure the `Console` transport for the returned logger.
+`createLogger` builds a winston `Logger` with a pre-configured `Console` transport and a set of logger-level formats that apply to every transport.
 
-| Option           | Description                                                                                                                                                                                                                    |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `consoleFormat`  | Either `pretty` (useful for local development) or `json` (default)                                                                                                                                                             |
-| `consoleOptions` | The `ConsoleTransportOptions` passed into the `Console` transport, useful for setting `silent`, e.g. to switch off output during test runs, per-transport `level` etc.                                                         |
-| `loggerOptions`  | The `LoggerOptions` passed into the `Logger`, useful for the `level`, `defaultMeta` and other customisations.                                                                                                                  |
-| `loggerOptions`  | The `LoggerOptions` passed into the `Logger`, useful for the `level`, `defaultMeta` and other customisations.                                                                                                                  |
-| `omitPaths`      | Paths of fields you wish to omit form logging. For example, during local development you may wish to hide values from `defaultMeta`, e.g. user context which would be omitted in every log entry and irrelevent for local dev. |
-| `transports`     | Extra `Transport`s you wish to add to the logger.                                                                                                                                                                              |
+Formats are applied in two layers:
 
-At MakerX we generally use config files to control logging output across local development and deployed environments:
+- **Logger-level** (applied to all transports, in order): `serializeErrorFormat` → `omitFormat` (if `omitPaths`) → `redactFormat` (if `redactPaths`) → `loggerOptions.format` (if supplied) → `jsonStringifyValuesFormat` (if `flatten`; always last so it captures every prior transformation).
+- **Console transport** (applied to Console output only): `omitNilFormat` → any `consoleFormats` → either `prettyConsoleFormat` (when `consoleFormat: 'pretty'`) or `timestamp` + `json` (when `consoleFormat: 'json'`).
 
-logger.ts
+### Options
+
+| Option            | Type                      | Description                                                                                                                                                                                          |
+| ----------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `consoleFormat`   | `'json' \| 'pretty'`      | Output format for the Console transport. `json` (default) for deployed environments, `pretty` for colourised YAML during local development.                                                          |
+| `consoleOptions`  | `ConsoleTransportOptions` | Options forwarded to the Console transport (e.g. `silent`, per-transport `level`). The `format` property is managed by this library.                                                                 |
+| `consoleFormats`  | `Format[]`                | Extra formats appended to the Console transport's format chain, before the final `json`/`pretty` step. Applies to the Console transport only.                                                        |
+| `transports`      | `Transport[]`             | Additional winston transports attached alongside the Console transport.                                                                                                                              |
+| `omitPaths`       | `string[]`                | Dot-notation paths to remove from every log entry. Applied at the logger level, so affects all transports.                                                                                           |
+| `redactPaths`     | `string[]`                | Dot-notation paths whose values are replaced with `redactedValue`. Applied at the logger level, so affects all transports.                                                                           |
+| `redactedValue`   | `string`                  | Replacement value used by `redactPaths`. Defaults to `'<redacted>'`.                                                                                                                                 |
+| `flatten`         | `boolean`                 | When `true`, serialises every top-level value on the log info to a JSON string, producing a flat `{ key: string }` shape for transports that expect scalar values (e.g. OTEL + Azure Log Analytics). |
+| `flattenReplacer` | `(key, value) => any`     | Optional `JSON.stringify` replacer used when `flatten` serialises each top-level value.                                                                                                              |
+| `loggerOptions`   | `LoggerOptions`           | Winston logger options (e.g. `level`, `defaultMeta`). A `format` supplied here is appended after the library's logger-level formats but still runs before `flatten` when enabled.                    |
+
+### Log levels
+
+`createLogger` applies a level set where `debug` is noisier than `verbose` (unlike winston's default, which has them reversed). This matches the convention used by Seq, CloudWatch and most log aggregators, where Verbose/Trace is expected to be the lowest, noisiest level. An `audit` level sits between `warn` and `info` for audit-trail events that should flow through at `info` and above but be filtered at `warn`:
 
 ```ts
-import { isLocalDev } from '@makerxstudio/node-common'
-import { createLogger } from '@makerxstudio/node-winston'
+{ error: 0, warn: 1, audit: 2, info: 3, debug: 4, verbose: 5 }
+```
+
+Colours for the default levels (including `audit`) are registered at module load, so `colorize` / pretty output works out of the box.
+
+Pass your own `levels` via `loggerOptions` to override. When you do, the returned logger is typed against your level keys (so `logger.audit` is only present when the default levels are in use), and you should register colours for your levels via `winston.addColors`:
+
+```ts
+import { addColors } from 'winston'
+import { createLogger } from '@makerx/node-winston'
+
+const logger = createLogger({
+  loggerOptions: { levels: { fatal: 0, error: 1, info: 2, trace: 3 }, level: 'info' },
+})
+
+addColors({ fatal: 'red', error: 'red', info: 'green', trace: 'cyan' })
+
+logger.fatal('process is exiting') // typed; logger.audit would be a type error
+```
+
+### Example: environment-driven configuration
+
+At MakerX we typically drive logger configuration from config files, varying output by environment:
+
+`logger.ts`:
+
+```ts
+import { isLocalDev } from '@makerx/node-common'
+import { createLogger } from '@makerx/node-winston'
 import config from 'config'
 
 const logger = createLogger({
@@ -36,45 +80,37 @@ const logger = createLogger({
 export default logger
 ```
 
-This would translate into different runtime configurations:
+Runtime configurations for different environments might look like:
 
 ```ts
-// local development logger would be created something like...
+// local development — coloured YAML, verbose level, strip redundant defaultMeta
 const logger = createLogger({
   consoleFormat: 'pretty',
   loggerOptions: {
-    defaultMeta: {
-      service: 'my-application-name',
-    },
+    defaultMeta: { service: 'my-application-name' },
     level: 'verbose',
   },
-  omitPaths: ['service'], // defaultMeta.service is set in the default (all environments) config, localdev config strips this from output
+  omitPaths: ['service'],
 })
 
-// deployed environment logger would be created something like...
+// deployed — structured JSON, info level
 const logger = createLogger({
   consoleFormat: 'json',
   loggerOptions: {
-    defaultMeta: {
-      service: 'my-application-name',
-    },
+    defaultMeta: { service: 'my-application-name' },
     level: 'info',
   },
 })
 
-// integration tests could silence noisy console output by setting process.env.SILENT_CONSOLE to 'true'
+// integration tests — silence console output
 const logger = createLogger({
-  consoleOptions: {
-    silent: true,
-  },
+  consoleOptions: { silent: true },
 })
 ```
 
 ## Transports
 
-The `createLogger` method creates (only) a `Console` transport.
-
-If you wish to add [other transports](https://github.com/winstonjs/winston/blob/master/docs/transports.md), pass them in via the `transports` option, e.g.
+`createLogger` creates a `Console` transport by default. Add [other transports](https://github.com/winstonjs/winston/blob/master/docs/transports.md) via the `transports` option — they share the logger-level formats:
 
 ```ts
 const logger = createLogger({
@@ -93,36 +129,55 @@ const logger = createLogger({
 
 ## Formats
 
-`createLogger` applies some default behaviour, chaining `omitNilFormat` and `omitFormat` in front of the final json or coloured YAML format.
+Every format used by `createLogger` is also exported for direct use with your own winston setup.
 
-- `omitNilFormat` removes null or undefined values from output
-- `omitFormat` removes values by path using [es-toolkit's compat omit](https://es-toolkit.dev/reference/compat/object/omit.html) (lodash-compatible, supports dot-notation paths)
-- `prettyConsoleFormat` applies the `colorize` and `timestamp` formats before formatting logs as coloured YAML
+| Format                      | Purpose                                                                                                                                                                |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serializeErrorFormat`      | Walks the log info (including nested objects and arrays) and replaces `Error` instances with plain objects that include the normally non-enumerable `message`/`stack`. |
+| `omitFormat`                | Removes fields by dot-notation path via [es-toolkit's compat `omit`](https://es-toolkit.dev/reference/compat/object/omit.html) (lodash-compatible).                    |
+| `omitNilFormat`             | Removes top-level `null` or `undefined` values.                                                                                                                        |
+| `redactFormat`              | Recursively replaces values at the given paths with `redactedValue` (default `'<redacted>'`).                                                                          |
+| `jsonStringifyValuesFormat` | Serialises every top-level value to a JSON string, producing a flat `{ key: string }` shape. Accepts an optional `replacer`.                                           |
+| `prettyConsoleFormat`       | Applies `colorize` and `timestamp`, then renders logs as coloured YAML using [`yamlify-object`](https://www.npmjs.com/package/yamlify-object).                         |
 
-If you wish to add additional formats, pass them in via the `consoleFormats` option.
+Direct usage example:
+
+```ts
+import { format, createLogger } from 'winston'
+import { Console } from 'winston/lib/winston/transports'
+import { redactFormat, serializeErrorFormat } from '@makerx/node-winston'
+
+const logger = createLogger({
+  format: format.combine(serializeErrorFormat(), redactFormat({ paths: ['user.email'] })),
+  transports: [new Console({ format: format.json() })],
+})
+```
 
 ### Error serialization
 
-The `Error` class's `message` and `stack` properties [are not enumerable](https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify); the output of `JSON.stringify(new Error('message'))` is `'{}'`.
+The `Error` class's `message` and `stack` properties [are not enumerable](https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify), so `JSON.stringify(new Error('message'))` returns `'{}'`.
 
-Winston has some special handling, so that when an error is the first or second argument, message and stack props are logged:
+Winston has special handling when an `Error` is the first or second argument to a log call:
 
 ```ts
-logger.log(new Error('cause')) // {message: 'cause', stack: ...}
-logger.log('message', new Error('cause')) // {message: 'message cause', stack: ...}
+logger.log(new Error('cause')) // { message: 'cause', stack: ... }
+logger.log('message', new Error('cause')) // { message: 'message cause', stack: ... }
 ```
 
-However, when errors are nested in structured log data, message and stack props are lost:
+But when errors are nested inside structured log data, `message` and `stack` are lost:
 
 ```ts
-catch (error) {
-  logger.log('message', { info, error }) // {message: 'message', error: {}}
+try {
+  /* ... */
+} catch (error) {
+  logger.log('message', { info, error }) // { message: 'message', error: {} }
 }
 ```
 
-Winston [logform](https://github.com/winstonjs/logform) uses [safe-stable-stringify](https://www.npmjs.com/package/safe-stable-stringify) which supports a `replacer`, similar to `JSON.stringify`.
+`createLogger` solves this with two complementary mechanisms:
 
-In `createLogger` we use `serializableErrorReplacer` via the JSON format options to ensure that the `message` and `stack` properties of errors are serialized to error logs:
+- `serializeErrorFormat` runs at the logger level and walks the log info, replacing any `Error` instance (at any depth) with a plain, JSON-serializable object that includes `name`, `message` and `stack`. This applies to every transport.
+- `serializableErrorReplacer` is passed to the Console transport's final `format.json()` as a safety net — [logform](https://github.com/winstonjs/logform) uses [safe-stable-stringify](https://www.npmjs.com/package/safe-stable-stringify), which accepts a replacer, so any `Error` that slips through is still serialised correctly.
 
 ```ts
 format.json({ replacer: serializableErrorReplacer })

--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ A set of [winston](https://github.com/winstonjs/winston) [formats](https://githu
 npm install @makerx/node-winston
 ```
 
-`winston`, `logform`, `winston-transport`, `triple-beam` and `es-toolkit` are declared as peer dependencies, so bring your own versions (>=3, >=2, >=4, >=1, >=1 respectively).
+`winston`, `logform`, `winston-transport`, `triple-beam`, `es-toolkit` and `serialize-error` are declared as peer dependencies, so bring your own versions (>=3, >=2, >=4, >=1, >=1, >=13 respectively).
+
+Requires Node.js `>=22.12` (for flag-free `require(esm)` support, needed by `serialize-error`'s ESM-only publish).
 
 ## Migrating from v1
 
 Breaking changes:
 
 - The `lodash` dependency has been replaced with `es-toolkit` as a peer dependency.
+- `serialize-error` is now a peer dependency used for `Error` serialisation — consumers get the well-tested package behaviour (own-prop capture, `cause` chains, circular refs) out of the box.
+- Node.js `>=22.12` is required (for flag-free `require(esm)`, needed by `serialize-error`'s ESM-only publish).
 - `omitPaths` now applies at the logger level and affects every transport, not just the Console transport. If you added custom transports expecting the unredacted object, move omit/redact handling into that transport's format.
 - A new `audit` level sits between `warn` and `info`. Loggers configured at `level: 'info'` (or more verbose) will now include `audit` messages; loggers at `level: 'warn'` or higher still filter them out.
 - Pass a custom `levels` map via `loggerOptions` to opt out of the default level set (including `audit`); the returned logger type narrows to your keys.
@@ -23,7 +27,7 @@ New functionality:
 
 - New `redactPaths` / `redactedValue` options replace values at dot-notation paths across every transport. Also available as the standalone `redactFormat`, and the `redactValues` / `redactValuesWith` helpers for direct use.
 - New `flatten` / `flattenReplacer` options serialise every top-level value on the log info to a JSON string, producing a flat `{ key: string }` shape suited to OTEL + Azure Log Analytics and other scalar-only aggregators. Also available as `jsonStringifyValuesFormat` and `jsonStringifyValues`.
-- Errors nested inside structured metadata are now fully serialised at the logger level (not just the Console transport) via the new `serializeErrorFormat`. It walks the whole info object — including nested objects and arrays — replacing every `Error` with a plain object that carries `name`, `message` and `stack`.
+- Errors nested inside structured metadata are now fully serialised at the logger level (not just the Console transport) via the new `serializeErrorFormat`. It walks the whole info object — including nested objects and arrays — replacing every `Error` with a plain object that carries `name`, `message` and `stack`. The serializer is pluggable: pass `errorSerializer` to `createLogger` (or `serializer` to `serializeErrorFormat` directly) to swap in your own transformation — useful when migrating from a winston-transport patch that already normalises errors.
 - `createLogger` is now generic over the level map. When you pass `loggerOptions.levels`, the returned logger's method signatures narrow to your level keys (`logger.fatal(...)` becomes valid, `logger.audit` becomes a type error).
 - Colours for the default levels (including `audit`) are registered on first use of the default levels, so `colorize` / pretty output works out of the box without a module-load side effect.
 - `defaultLevels` is exported directly if you want to extend or re-use it.
@@ -39,18 +43,19 @@ Formats are applied in two layers:
 
 ### Options
 
-| Option            | Type                      | Description                                                                                                                                                                                          |
-| ----------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `consoleFormat`   | `'json' \| 'pretty'`      | Output format for the Console transport. `json` (default) for deployed environments, `pretty` for colourised YAML during local development.                                                          |
-| `consoleOptions`  | `ConsoleTransportOptions` | Options forwarded to the Console transport (e.g. `silent`, per-transport `level`). The `format` property is managed by this library.                                                                 |
-| `consoleFormats`  | `Format[]`                | Extra formats appended to the Console transport's format chain, before the final `json`/`pretty` step. Applies to the Console transport only.                                                        |
-| `transports`      | `Transport[]`             | Additional winston transports attached alongside the Console transport.                                                                                                                              |
-| `omitPaths`       | `string[]`                | Dot-notation paths to remove from every log entry. Applied at the logger level, so affects all transports.                                                                                           |
-| `redactPaths`     | `string[]`                | Dot-notation paths whose values are replaced with `redactedValue`. Applied at the logger level, so affects all transports.                                                                           |
-| `redactedValue`   | `string`                  | Replacement value used by `redactPaths`. Defaults to `'<redacted>'`.                                                                                                                                 |
-| `flatten`         | `boolean`                 | When `true`, serialises every top-level value on the log info to a JSON string, producing a flat `{ key: string }` shape for transports that expect scalar values (e.g. OTEL + Azure Log Analytics). |
-| `flattenReplacer` | `(key, value) => any`     | Optional `JSON.stringify` replacer used when `flatten` serialises each top-level value.                                                                                                              |
-| `loggerOptions`   | `LoggerOptions`           | Winston logger options (e.g. `level`, `defaultMeta`). A `format` supplied here is appended after the library's logger-level formats but still runs before `flatten` when enabled.                    |
+| Option            | Type                      | Description                                                                                                                                                                                                                                                                                    |
+| ----------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `consoleFormat`   | `'json' \| 'pretty'`      | Output format for the Console transport. `json` (default) for deployed environments, `pretty` for colourised YAML during local development.                                                                                                                                                    |
+| `consoleOptions`  | `ConsoleTransportOptions` | Options forwarded to the Console transport (e.g. `silent`, per-transport `level`). The `format` property is managed by this library.                                                                                                                                                           |
+| `consoleFormats`  | `Format[]`                | Extra formats appended to the Console transport's format chain, before the final `json`/`pretty` step. Applies to the Console transport only.                                                                                                                                                  |
+| `transports`      | `Transport[]`             | Additional winston transports attached alongside the Console transport.                                                                                                                                                                                                                        |
+| `omitPaths`       | `string[]`                | Dot-notation paths to remove from every log entry. Applied at the logger level, so affects all transports.                                                                                                                                                                                     |
+| `redactPaths`     | `string[]`                | Dot-notation paths whose values are replaced with `redactedValue`. Applied at the logger level, so affects all transports.                                                                                                                                                                     |
+| `redactedValue`   | `string`                  | Replacement value used by `redactPaths`. Defaults to `'<redacted>'`.                                                                                                                                                                                                                           |
+| `flatten`         | `boolean`                 | When `true`, serialises every top-level value on the log info to a JSON string, producing a flat `{ key: string }` shape for transports that expect scalar values (e.g. OTEL + Azure Log Analytics).                                                                                           |
+| `flattenReplacer` | `(key, value) => any`     | Optional `JSON.stringify` replacer used when `flatten` serialises each top-level value.                                                                                                                                                                                                        |
+| `errorSerializer` | `ErrorSerializer`         | Custom serializer applied to every `Error` instance at the logger level (via `serializeErrorFormat`) and as the Console transport's `format.json` replacer. Defaults to the library's `serializeError`, which delegates to [`serialize-error`](https://www.npmjs.com/package/serialize-error). |
+| `loggerOptions`   | `LoggerOptions`           | Winston logger options (e.g. `level`, `defaultMeta`). A `format` supplied here is appended after the library's logger-level formats but still runs before `flatten` when enabled.                                                                                                              |
 
 ### Log levels
 
@@ -194,9 +199,30 @@ try {
 
 `createLogger` solves this with two complementary mechanisms:
 
-- `serializeErrorFormat` runs at the logger level and walks the log info, replacing any `Error` instance (at any depth) with a plain, JSON-serializable object that includes `name`, `message` and `stack`. This applies to every transport.
+- `serializeErrorFormat` runs at the logger level and walks the log info, replacing any `Error` instance (at any depth) with a plain, JSON-serializable object (via the [`serialize-error`](https://www.npmjs.com/package/serialize-error) package). This applies to every transport.
 - `serializableErrorReplacer` is passed to the Console transport's final `format.json()` as a safety net — [logform](https://github.com/winstonjs/logform) uses [safe-stable-stringify](https://www.npmjs.com/package/safe-stable-stringify), which accepts a replacer, so any `Error` that slips through is still serialised correctly.
 
 ```ts
 format.json({ replacer: serializableErrorReplacer })
+```
+
+To plug in a custom transformation (for example, an `Error`-normalising function previously applied via a custom winston-transport), pass it via `errorSerializer` — it's threaded into both mechanisms:
+
+```ts
+import { createLogger } from '@makerx/node-winston'
+
+const logger = createLogger({
+  errorSerializer: (error) => ({ kind: error.name, detail: error.message, trace: error.stack }),
+})
+```
+
+For direct format usage, `serializeErrorFormat` accepts the same override and `createSerializableErrorReplacer(serializer)` builds a matching JSON replacer:
+
+```ts
+import { format } from 'winston'
+import { createSerializableErrorReplacer, serializeErrorFormat } from '@makerx/node-winston'
+
+const serializer = (error: Error) => ({ kind: error.name, detail: error.message })
+
+format.combine(serializeErrorFormat({ serializer }), format.json({ replacer: createSerializableErrorReplacer(serializer) }))
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ npm install @makerx/node-winston
 
 `winston`, `logform`, `winston-transport`, `triple-beam` and `es-toolkit` are declared as peer dependencies, so bring your own versions (>=3, >=2, >=4, >=1, >=1 respectively).
 
+## Migrating from v1
+
+Breaking changes:
+
+- The `lodash` peer dependency has been replaced with `es-toolkit`. Install `es-toolkit` alongside winston (or it will be installed automatically).
+- `omitPaths` now applies at the logger level and affects every transport, not just the Console transport. If you added custom transports expecting the unredacted object, move omit/redact handling into that transport's format.
+- A new `audit` level sits between `warn` and `info`. Loggers configured at `level: 'info'` (or more verbose) will now include `audit` messages; loggers at `level: 'warn'` or higher still filter them out.
+- Pass a custom `levels` map via `loggerOptions` to opt out of the default level set (including `audit`); the returned logger type narrows to your keys.
+
+New functionality:
+
+- New `redactPaths` / `redactedValue` options replace values at dot-notation paths across every transport. Also available as the standalone `redactFormat`, and the `redactValues` / `redactValuesWith` helpers for direct use.
+- New `flatten` / `flattenReplacer` options serialise every top-level value on the log info to a JSON string, producing a flat `{ key: string }` shape suited to OTEL + Azure Log Analytics and other scalar-only aggregators. Also available as `jsonStringifyValuesFormat` and `jsonStringifyValues`.
+- Errors nested inside structured metadata are now fully serialised at the logger level (not just the Console transport) via the new `serializeErrorFormat`. It walks the whole info object — including nested objects and arrays — replacing every `Error` with a plain object that carries `name`, `message` and `stack`.
+- `createLogger` is now generic over the level map. When you pass `loggerOptions.levels`, the returned logger's method signatures narrow to your level keys (`logger.fatal(...)` becomes valid, `logger.audit` becomes a type error).
+- Colours for the default levels (including `audit`) are registered on first use of the default levels, so `colorize` / pretty output works out of the box without a module-load side effect.
+- `defaultLevels` is exported directly if you want to extend or re-use it.
+
 ## Creating a Logger
 
 `createLogger` builds a winston `Logger` with a pre-configured `Console` transport and a set of logger-level formats that apply to every transport.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/node-winston",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/node-winston",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
@@ -35,20 +35,20 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^5.5.5",
         "npm-run-all": "^4.1.5",
-        "prettier": "3.8.3",
         "rimraf": "^6.1.3",
-        "rollup": "4.60.2",
+        "serialize-error": "^13.0.1",
         "tslib": "^2.8.1",
         "tsx": "4.21.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=16.0"
+        "node": ">=22.12"
       },
       "peerDependencies": {
         "es-toolkit": ">=1",
         "logform": ">=2",
+        "serialize-error": ">=13",
         "triple-beam": ">=1",
         "winston": ">=3",
         "winston-transport": ">=4"
@@ -1270,356 +1270,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@so-ric/colorspace": {
       "version": "1.1.6",
@@ -5259,6 +4909,19 @@
         "readable-stream": "~1.0.31"
       }
     },
+    "node_modules/non-error": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/non-error/-/non-error-0.1.0.tgz",
+      "integrity": "sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -5813,6 +5476,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6111,51 +5775,6 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -6253,6 +5872,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-13.0.1.tgz",
+      "integrity": "sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "non-error": "^0.1.0",
+        "type-fest": "^5.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/set-function-length": {
@@ -6744,6 +6380,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -6919,6 +6568,22 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/node-winston",
-  "version": "2.0.0",
+  "version": "2.0.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/node-winston",
-      "version": "2.0.0",
+      "version": "2.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-plugin-prettier": "^5.5.5",
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.1.3",
+        "rollup": "4.60.2",
         "serialize-error": "^13.0.1",
         "tslib": "^2.8.1",
         "tsx": "4.21.0",
@@ -1270,6 +1271,395 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@so-ric/colorspace": {
       "version": "1.1.6",
@@ -5773,6 +6163,51 @@
         "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
         "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/safe-array-concat": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@rollup/plugin-typescript": "^12.3.0",
         "@tsconfig/node20": "20.1.9",
         "@types/express": "^5.0.6",
-        "@types/lodash": "^4.17.12",
         "@types/node": "25.6.0",
         "@typescript-eslint/eslint-plugin": "8.58.1",
         "@typescript-eslint/parser": "8.58.1",
@@ -48,7 +47,7 @@
         "node": ">=16.0"
       },
       "peerDependencies": {
-        "lodash": ">=4",
+        "es-toolkit": ">=1",
         "logform": ">=2",
         "triple-beam": ">=1",
         "winston": ">=3",
@@ -1743,13 +1742,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -3118,6 +3110,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es5-ext": {
       "version": "0.10.64",
@@ -5028,13 +5031,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/node-winston",
-  "version": "2.0.0",
+  "version": "2.0.0-beta.0",
   "private": false,
   "description": "A set of winston formats, console transport and logger creation functions",
   "author": "MakerX",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/node-winston",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "private": false,
   "description": "A set of winston formats, console transport and logger creation functions",
   "author": "MakerX",
@@ -48,7 +48,6 @@
     "@rollup/plugin-typescript": "^12.3.0",
     "@tsconfig/node20": "20.1.9",
     "@types/express": "^5.0.6",
-    "@types/lodash": "^4.17.12",
     "@types/node": "25.6.0",
     "@typescript-eslint/eslint-plugin": "8.58.1",
     "@typescript-eslint/parser": "8.58.1",
@@ -69,7 +68,7 @@
     "vitest": "^4.1.4"
   },
   "peerDependencies": {
-    "lodash": ">=4",
+    "es-toolkit": ">=1",
     "logform": ">=2",
     "triple-beam": ">=1",
     "winston": ">=3",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-prettier": "^5.5.5",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.1.3",
+    "rollup": "4.60.2",
     "serialize-error": "^13.0.1",
     "tslib": "^2.8.1",
     "tsx": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "index.d.ts",
   "main": "index.cjs",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=22.12"
   },
   "bugs": {
     "url": "https://github.com/MakerXStudio/node-winston/issues"
@@ -59,9 +59,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.5.5",
     "npm-run-all": "^4.1.5",
-    "prettier": "3.8.3",
     "rimraf": "^6.1.3",
-    "rollup": "4.60.2",
+    "serialize-error": "^13.0.1",
     "tslib": "^2.8.1",
     "tsx": "4.21.0",
     "typescript": "^6.0.2",
@@ -70,6 +69,7 @@
   "peerDependencies": {
     "es-toolkit": ">=1",
     "logform": ">=2",
+    "serialize-error": ">=13",
     "triple-beam": ">=1",
     "winston": ">=3",
     "winston-transport": ">=4"

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,6 +1,7 @@
-import { createLogger } from './index'
+import { format } from 'winston'
 import TransportStream from 'winston-transport'
 import { describe, expect, it } from 'vitest'
+import { createLogger } from './index'
 
 describe('logger', () => {
   it('verbose logs are screened out when level is debug', () => {
@@ -23,21 +24,213 @@ describe('logger', () => {
   })
 })
 
+describe('createLogger audit level', () => {
+  it('writes audit logs at the audit level', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({ consoleOptions: { silent: true }, transports: [transport] })
+    logger.audit('audit-event', { actor: 'user-1' })
+    expect(transport.logs.length).toBe(1)
+    expect(transport.logs[0].level).toBe('audit')
+    expect(transport.logs[0].message).toBe('audit-event')
+    expect((transport.logs[0] as { actor: string }).actor).toBe('user-1')
+  })
+
+  it('includes audit logs at info level and filters them at warn level', () => {
+    const infoTransport = new InMemoryTransport({})
+    const infoLogger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [infoTransport],
+      loggerOptions: { level: 'info' },
+    })
+    infoLogger.audit('included-at-info')
+
+    const warnTransport = new InMemoryTransport({})
+    const warnLogger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [warnTransport],
+      loggerOptions: { level: 'warn' },
+    })
+    warnLogger.audit('filtered-at-warn')
+
+    expect(infoTransport.logs.map((l) => l.message)).toEqual(['included-at-info'])
+    expect(warnTransport.logs.length).toBe(0)
+  })
+})
+
+describe('createLogger custom levels', () => {
+  it('exposes the custom level methods and omits the defaults from the type', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [transport],
+      loggerOptions: { levels: { fatal: 0, trace: 1 }, level: 'trace' },
+    })
+    logger.fatal('bang')
+    logger.trace('tick')
+    expect(transport.logs.map((l) => l.level)).toEqual(['fatal', 'trace'])
+    // @ts-expect-error audit is not part of the custom level set
+    logger.audit
+  })
+})
+
+describe('createLogger error serialization', () => {
+  it('serializes an Error passed as structured metadata', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({ consoleOptions: { silent: true }, transports: [transport] })
+    logger.info('boom', { error: new Error('cause') })
+    const { error } = transport.logs[0] as { error: { name: string; message: string; stack: string } }
+    expect(error.name).toBe('Error')
+    expect(error.message).toBe('cause')
+    expect(error.stack).toContain('Error: cause')
+  })
+
+  it('serializes errors nested inside objects and arrays', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({ consoleOptions: { silent: true }, transports: [transport] })
+    logger.info('nested', { ctx: { cause: new Error('deep') }, items: [{ err: new Error('in-array') }] })
+    const info = transport.logs[0] as {
+      ctx: { cause: { message: string } }
+      items: [{ err: { message: string } }]
+    }
+    expect(info.ctx.cause.message).toBe('deep')
+    expect(info.items[0].err.message).toBe('in-array')
+  })
+})
+
+describe('createLogger omitPaths', () => {
+  it('removes top-level and nested dot-path fields', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [transport],
+      omitPaths: ['service', 'user.password'],
+    })
+    logger.info('hello', { service: 'svc', user: { id: 1, password: 'secret' } })
+    const info = transport.logs[0] as { service?: string; user: { id: number; password?: string } }
+    expect(info.service).toBeUndefined()
+    expect(info.user).toEqual({ id: 1 })
+  })
+})
+
+describe('createLogger redactPaths', () => {
+  it('redacts values at the given paths with the default value', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [transport],
+      redactPaths: ['authorization', 'user.email'],
+    })
+    logger.info('hello', { authorization: 'Bearer abc', user: { id: 1, email: 'x@y.z' } })
+    const info = transport.logs[0] as { authorization: string; user: { id: number; email: string } }
+    expect(info.authorization).toBe('<redacted>')
+    expect(info.user.email).toBe('<redacted>')
+    expect(info.user.id).toBe(1)
+  })
+
+  it('honours a custom redactedValue', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [transport],
+      redactPaths: ['token'],
+      redactedValue: '***',
+    })
+    logger.info('hello', { token: 'abc' })
+    expect((transport.logs[0] as { token: string }).token).toBe('***')
+  })
+
+  it('redacts matching keys inside arrays recursively', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [transport],
+      redactPaths: ['email'],
+    })
+    logger.info('hello', { users: [{ email: 'a@b.c' }, { email: 'd@e.f' }] })
+    const info = transport.logs[0] as { users: { email: string }[] }
+    expect(info.users.map((u) => u.email)).toEqual(['<redacted>', '<redacted>'])
+  })
+})
+
+describe('createLogger child loggers', () => {
+  it('merges metadata across chained .child() calls', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({ consoleOptions: { silent: true }, transports: [transport] })
+    const requestLogger = logger.child({ requestInfo: { id: 'req-1', path: '/items' } })
+    const instanceLogger = requestLogger.child({ instanceInfo: { podId: 'pod-42' } })
+    instanceLogger.info('handled')
+    const info = transport.logs[0] as {
+      message: string
+      requestInfo: { id: string; path: string }
+      instanceInfo: { podId: string }
+    }
+    expect(info.message).toBe('handled')
+    expect(info.requestInfo).toEqual({ id: 'req-1', path: '/items' })
+    expect(info.instanceInfo).toEqual({ podId: 'pod-42' })
+  })
+})
+
+describe('createLogger flatten', () => {
+  it('stringifies object and array values and leaves scalars alone', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [transport],
+      flatten: true,
+    })
+    logger.info('hello', { obj: { a: 1 }, arr: [1, 2], count: 3, flag: true, text: 'literal' })
+    const info = transport.logs[0] as Record<string, unknown>
+    expect(info.obj).toBe('{"a":1}')
+    expect(info.arr).toBe('[1,2]')
+    expect(info.count).toBe(3)
+    expect(info.flag).toBe(true)
+    expect(info.text).toBe('literal')
+  })
+
+  it('forwards flattenReplacer to JSON.stringify for each value', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [transport],
+      flatten: true,
+      flattenReplacer: (key, value) => (key === 'secret' ? '<hidden>' : value),
+    })
+    logger.info('hello', { data: { secret: 'abc', other: 'def' } })
+    const { data } = transport.logs[0] as { data: string }
+    const parsed = JSON.parse(data) as { secret: string; other: string }
+    expect(parsed.secret).toBe('<hidden>')
+    expect(parsed.other).toBe('def')
+  })
+
+  it('runs after loggerOptions.format so injected object values are stringified', () => {
+    const transport = new InMemoryTransport({})
+    const injectFormat = format((info) => {
+      info.injected = { a: 1 }
+      return info
+    })
+    const logger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [transport],
+      flatten: true,
+      loggerOptions: { format: injectFormat() },
+    })
+    logger.info('hello')
+    expect((transport.logs[0] as { injected: unknown }).injected).toBe('{"a":1}')
+  })
+})
+
 class InMemoryTransport extends TransportStream {
-  logs: {
-    level: string
-    message: string
-  }[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  logs: Record<string, any>[]
 
   constructor(opts: TransportStream.TransportStreamOptions) {
     super(opts)
     this.logs = []
   }
 
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   log(info: any, next: () => void): void {
-    const { level, message } = info
-    this.logs.push({ level, message })
+    this.logs.push({ ...(info as Record<string, unknown>) })
     next()
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,54 +1,125 @@
 import { format, Format } from 'logform'
-import { createLogger as winstonCreateLogger, Logger as WinstonLogger, LoggerOptions } from 'winston'
+import { createLogger as winstonCreateLogger, Logger as WinstonLogger, LoggerOptions, LeveledLogMethod, addColors } from 'winston'
 import * as Transport from 'winston-transport'
 import { Console, ConsoleTransportOptions } from 'winston/lib/winston/transports'
+import { jsonStringifyValuesFormat } from './json-stringify-values-format'
 import { omitFormat } from './omit-format'
 import { omitNilFormat } from './omit-nil-format'
 import { prettyConsoleFormat } from './pretty-console-format'
+import { redactFormat } from './redact-format'
 import { serializableErrorReplacer } from './serialize-error'
+import { serializeErrorFormat } from './serialize-error-format'
 
+export * from './json-stringify-values'
+export * from './json-stringify-values-format'
 export * from './omit-format'
 export * from './omit-nil-format'
 export * from './pretty-console-format'
+export * from './redact-format'
+export * from './redact-values'
 export * from './serialize-error'
-
-export type Logger = Pick<
-  WinstonLogger,
-  // Supports child loggers
-  | 'child'
-  // Common levels
-  | 'debug'
-  | 'error'
-  | 'info'
-  | 'verbose'
-  | 'warn'
-  // General log method
-  | 'log'
->
+export * from './serialize-error-format'
 
 // winstonjs' default levels have debug and verbose reversed, which is confusing and causes filtering issues with Seq,
-// CloudWatch etc (given they assume Verbose/Trace should be the lowest/noisiest log level)
-const levels = {
+// CloudWatch etc (given they assume Verbose/Trace should be the lowest/noisiest log level).
+// `audit` sits between `warn` and `info`, so audit logs are included at `info` and above but filtered at `warn`.
+export const defaultLevels = {
   error: 0,
   warn: 1,
+  audit: 2,
   info: 3,
   debug: 4,
   verbose: 5,
 }
 
+// Register colours for the default levels so `colorize` / pretty output works out of the box.
+// Callers who override `levels` should register their own colours via `winston.addColors`.
+addColors({
+  error: 'red',
+  warn: 'yellow',
+  audit: 'magenta',
+  info: 'green',
+  debug: 'blue',
+  verbose: 'cyan',
+})
+
+export type LoggerWithLevels<L extends Record<string, number>> = Pick<WinstonLogger, 'child' | 'log'> & {
+  [K in keyof L]: LeveledLogMethod
+}
+
+export type Logger = LoggerWithLevels<typeof defaultLevels>
+
 export interface CreateLoggerOptions {
+  /**
+   * Output format for the Console transport.
+   * - `json` (default) — structured JSON output, suitable for deployed environments.
+   * - `pretty` — colourised YAML output, useful for local development.
+   */
   consoleFormat?: 'pretty' | 'json'
+
+  /**
+   * Additional winston transports to attach to the logger, alongside the built-in Console transport.
+   */
   transports?: Transport[]
+
+  /**
+   * Options forwarded to the built-in Console transport (e.g. `silent`, per-transport `level`).
+   * The `format` property is managed by this library and cannot be overridden here.
+   */
   consoleOptions?: Omit<ConsoleTransportOptions, 'format'>
+
+  /**
+   * Extra formats appended to the Console transport's format chain, before the final
+   * `json`/`pretty` step. Applies to the Console transport only.
+   */
   consoleFormats?: Format[]
+
+  /**
+   * Dot-notation paths to remove from every log entry. Applied at the logger level, so affects all transports.
+   * @example ['user.password', 'service']
+   */
   omitPaths?: string[]
+
+  /**
+   * Dot-notation paths whose values are replaced with `redactedValue` on every log entry.
+   * Applied at the logger level, so affects all transports.
+   * @example ['user.email', 'authorization']
+   */
+  redactPaths?: string[]
+
+  /**
+   * Replacement value used by `redactPaths`. Defaults to `'<redacted>'`.
+   */
+  redactedValue?: string
+
+  /**
+   * When `true`, appends `jsonStringifyValuesFormat` as the final logger-level format — applied after every
+   * other logger-level format (including any `loggerOptions.format`) — serialising every top-level value on
+   * the log info to a JSON string. Produces a flat `{ key: string }` shape suitable for transports/aggregators
+   * that expect scalar values (e.g. OTEL + Azure Log Analytics).
+   */
+  flatten?: boolean
+
+  /**
+   * Optional `JSON.stringify` replacer forwarded to `flatten` when serialising each top-level value.
+   * Only applied when `flatten` is `true`.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  flattenReplacer?: (this: any, key: string, value: any) => any
+
+  /**
+   * Winston `LoggerOptions` forwarded to the underlying logger (e.g. `level`, `defaultMeta`).
+   * `transports` is managed by this library; pass extras via `transports` instead.
+   * A `format` provided here is appended after the library's logger-level formats, but still runs
+   * before `flatten` (which is always last when enabled).
+   */
   loggerOptions?: Omit<LoggerOptions, 'transports'>
 }
 
-export const createConsoleTransport = ({ consoleFormat = 'json', consoleOptions, consoleFormats, omitPaths }: CreateLoggerOptions) => {
+export const createConsoleTransport = ({ consoleFormat = 'json', consoleOptions, consoleFormats }: CreateLoggerOptions) => {
   // aggregate the console formats
   const formats: Format[] = [omitNilFormat()]
-  if (omitPaths) formats.push(omitFormat({ paths: omitPaths }))
+
   if (consoleFormats) formats.push(...consoleFormats)
 
   // load the pretty format, if requested (and if dependencies available)
@@ -65,16 +136,32 @@ export const createConsoleTransport = ({ consoleFormat = 'json', consoleOptions,
   return new Console(options)
 }
 
-export const createLogger = (options: CreateLoggerOptions): Logger => {
+export function createLogger<const L extends Record<string, number>>(
+  options: CreateLoggerOptions & { loggerOptions: Omit<LoggerOptions, 'transports'> & { levels: L } },
+): LoggerWithLevels<L>
+export function createLogger(options: CreateLoggerOptions): Logger
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createLogger(options: CreateLoggerOptions): any {
+  const { omitPaths, redactPaths, redactedValue = '<redacted>', flatten, flattenReplacer } = options
+
   // aggregate transports
   const consoleTransport = createConsoleTransport(options)
   const transports: Transport[] = [consoleTransport]
   if (options.transports) transports.push(...options.transports)
 
-  // create logger options using supplied options + transports
+  // logger-level formats apply to all transports
+  const loggerFormats: Format[] = [serializeErrorFormat()]
+  if (omitPaths) loggerFormats.push(omitFormat({ paths: omitPaths }))
+  if (redactPaths) loggerFormats.push(redactFormat({ paths: redactPaths, redactedValue }))
+  if (options.loggerOptions?.format) loggerFormats.push(options.loggerOptions.format)
+  // flatten is applied last so all prior transformations are captured in the stringified values
+  if (flatten) loggerFormats.push(jsonStringifyValuesFormat({ replacer: flattenReplacer }))
+
+  // create logger options using supplied options + transports; loggerOptions.levels (if any) overrides defaultLevels
   const loggerOptions: LoggerOptions = {
-    levels, // loggerOptions should still be allowed to override our defaults
+    levels: defaultLevels,
     ...options.loggerOptions,
+    format: format.combine(...loggerFormats),
     transports,
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { omitFormat } from './omit-format'
 import { omitNilFormat } from './omit-nil-format'
 import { prettyConsoleFormat } from './pretty-console-format'
 import { redactFormat } from './redact-format'
-import { serializableErrorReplacer } from './serialize-error'
+import { createSerializableErrorReplacer, ErrorSerializer, serializeError } from './serialize-error'
 import { serializeErrorFormat } from './serialize-error-format'
 
 export * from './json-stringify-values'
@@ -116,6 +116,15 @@ export interface CreateLoggerOptions {
   flattenReplacer?: (this: any, key: string, value: any) => any
 
   /**
+   * Custom serializer used whenever an `Error` instance is encountered, both by the logger-level
+   * `serializeErrorFormat` (walks the full info tree) and by the Console transport's
+   * `format.json` replacer (safety net for errors that slip through). Defaults to the library's
+   * `serializeError`, which delegates to the
+   * [`serialize-error`](https://www.npmjs.com/package/serialize-error) package.
+   */
+  errorSerializer?: ErrorSerializer
+
+  /**
    * Winston `LoggerOptions` forwarded to the underlying logger (e.g. `level`, `defaultMeta`).
    * `transports` is managed by this library; pass extras via `transports` instead.
    * A `format` provided here is appended after the library's logger-level formats, but still runs
@@ -124,7 +133,12 @@ export interface CreateLoggerOptions {
   loggerOptions?: Omit<LoggerOptions, 'transports'>
 }
 
-export const createConsoleTransport = ({ consoleFormat = 'json', consoleOptions, consoleFormats }: CreateLoggerOptions) => {
+export const createConsoleTransport = ({
+  consoleFormat = 'json',
+  consoleOptions,
+  consoleFormats,
+  errorSerializer = serializeError,
+}: CreateLoggerOptions) => {
   // aggregate the console formats
   const formats: Format[] = [omitNilFormat()]
 
@@ -139,7 +153,7 @@ export const createConsoleTransport = ({ consoleFormat = 'json', consoleOptions,
     ...consoleOptions,
     format: prettyFormat
       ? format.combine(...formats, prettyFormat)
-      : format.combine(format.timestamp(), ...formats, format.json({ replacer: serializableErrorReplacer })),
+      : format.combine(format.timestamp(), ...formats, format.json({ replacer: createSerializableErrorReplacer(errorSerializer) })),
   }
   return new Console(options)
 }
@@ -150,7 +164,7 @@ export function createLogger<const L extends Record<string, number>>(
 export function createLogger(options: CreateLoggerOptions): Logger
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createLogger(options: CreateLoggerOptions): any {
-  const { omitPaths, redactPaths, redactedValue = '<redacted>', flatten, flattenReplacer } = options
+  const { omitPaths, redactPaths, redactedValue = '<redacted>', flatten, flattenReplacer, errorSerializer } = options
 
   // register default colours on first use of the default levels so `colorize` / pretty output works
   if (!options.loggerOptions?.levels) registerDefaultColors()
@@ -161,7 +175,7 @@ export function createLogger(options: CreateLoggerOptions): any {
   if (options.transports) transports.push(...options.transports)
 
   // logger-level formats apply to all transports
-  const loggerFormats: Format[] = [serializeErrorFormat()]
+  const loggerFormats: Format[] = [serializeErrorFormat({ serializer: errorSerializer })]
   if (omitPaths) loggerFormats.push(omitFormat({ paths: omitPaths }))
   if (redactPaths) loggerFormats.push(redactFormat({ paths: redactPaths, redactedValue }))
   if (options.loggerOptions?.format) loggerFormats.push(options.loggerOptions.format)

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,16 +32,24 @@ export const defaultLevels = {
   verbose: 5,
 }
 
-// Register colours for the default levels so `colorize` / pretty output works out of the box.
+// Colours for the default levels, registered on first `createLogger` call that uses them
+// so importing a single format doesn't silently mutate winston's global colour map.
 // Callers who override `levels` should register their own colours via `winston.addColors`.
-addColors({
+const defaultLevelColors = {
   error: 'red',
   warn: 'yellow',
   audit: 'magenta',
   info: 'green',
   debug: 'blue',
   verbose: 'cyan',
-})
+}
+
+let defaultColorsRegistered = false
+const registerDefaultColors = () => {
+  if (defaultColorsRegistered) return
+  addColors(defaultLevelColors)
+  defaultColorsRegistered = true
+}
 
 export type LoggerWithLevels<L extends Record<string, number>> = Pick<WinstonLogger, 'child' | 'log'> & {
   [K in keyof L]: LeveledLogMethod
@@ -143,6 +151,9 @@ export function createLogger(options: CreateLoggerOptions): Logger
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createLogger(options: CreateLoggerOptions): any {
   const { omitPaths, redactPaths, redactedValue = '<redacted>', flatten, flattenReplacer } = options
+
+  // register default colours on first use of the default levels so `colorize` / pretty output works
+  if (!options.loggerOptions?.levels) registerDefaultColors()
 
   // aggregate transports
   const consoleTransport = createConsoleTransport(options)

--- a/src/json-stringify-values-format.ts
+++ b/src/json-stringify-values-format.ts
@@ -2,9 +2,9 @@ import { TransformableInfo } from 'logform'
 import { format } from 'winston'
 
 /**
- * Serialises all top-level object values on the log info to JSON strings, producing
- * a flat `{ key: string }` shape suitable for OTEL transports that expect scalar values
- * (e.g. some log aggregators that index on string fields and suitable for OTEL + Azure Log Analytics).
+ * Serialises all top-level object values on the log info to JSON strings, producing a flat
+ * `{ key: string }` shape suitable for transports and aggregators that expect scalar values
+ * (e.g. OTEL + Azure Log Analytics).
  *
  * Accepts an optional `replacer` forwarded to `JSON.stringify` for each value.
  *

--- a/src/json-stringify-values-format.ts
+++ b/src/json-stringify-values-format.ts
@@ -1,0 +1,26 @@
+import { TransformableInfo } from 'logform'
+import { format } from 'winston'
+
+/**
+ * Serialises all top-level object values on the log info to JSON strings, producing
+ * a flat `{ key: string }` shape suitable for OTEL transports that expect scalar values
+ * (e.g. some log aggregators that index on string fields and suitable for OTEL + Azure Log Analytics).
+ *
+ * Accepts an optional `replacer` forwarded to `JSON.stringify` for each value.
+ *
+ * Mutates `info` in place so winston's Symbol-keyed routing props (`LEVEL`, `MESSAGE`, `SPLAT`)
+ * are preserved — returning a new object via `Object.fromEntries(Object.entries(info))` would drop them.
+ */
+export const jsonStringifyValuesFormat = format((info, opts) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { replacer } = (opts ?? {}) as { replacer?: (this: any, key: string, value: any) => any }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const record = info as Record<string, any>
+  for (const key of Object.keys(record)) {
+    const value = record[key]
+    if (value !== null && value !== undefined && typeof value === 'object') {
+      record[key] = JSON.stringify(value, replacer)
+    }
+  }
+  return info as TransformableInfo
+})

--- a/src/json-stringify-values.ts
+++ b/src/json-stringify-values.ts
@@ -1,0 +1,13 @@
+/**
+ * Serialises all top level object values to JSON, optionally using the supplied replacer
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function jsonStringifyValues(obj?: any, replacer?: (this: any, key: string, value: any) => any) {
+  if (!obj) return obj
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [
+      key,
+      value !== null && value !== undefined && typeof value === 'object' ? JSON.stringify(value as object, replacer) : value,
+    ]),
+  )
+}

--- a/src/omit-format.spec.ts
+++ b/src/omit-format.spec.ts
@@ -1,0 +1,42 @@
+import { TransformableInfo } from 'logform'
+import { LEVEL } from 'triple-beam'
+import { describe, expect, it } from 'vitest'
+import { omitFormat } from './omit-format'
+
+const runOmit = (paths: string[], info: Record<string, unknown>) => {
+  const opts = { paths }
+  const input = { [LEVEL]: 'info', level: 'info', message: '', ...info } as TransformableInfo
+  return omitFormat(opts).transform(input, opts) as Record<string, unknown>
+}
+
+describe('omitFormat', () => {
+  it('removes top-level keys', () => {
+    const result = runOmit(['password'], { message: 'hello', password: 'secret' })
+
+    expect(result).not.toHaveProperty('password')
+    expect(result).toHaveProperty('message', 'hello')
+  })
+
+  it('removes nested values via dot-notation paths', () => {
+    const result = runOmit(['user.credentials.token', 'auth.refreshToken'], {
+      message: 'authenticated',
+      user: {
+        id: 42,
+        credentials: { token: 'abc123', scheme: 'bearer' },
+      },
+      auth: {
+        refreshToken: 'xyz789',
+        issuer: 'example',
+      },
+    })
+
+    expect(result.user).toEqual({ id: 42, credentials: { scheme: 'bearer' } })
+    expect(result.auth).toEqual({ issuer: 'example' })
+  })
+
+  it('is a no-op for paths that do not exist', () => {
+    const result = runOmit(['user.missing.deeply.nested'], { user: { id: 1 } })
+
+    expect(result.user).toEqual({ id: 1 })
+  })
+})

--- a/src/omit-format.ts
+++ b/src/omit-format.ts
@@ -1,4 +1,4 @@
-import { omit } from 'lodash'
+import { omit } from 'es-toolkit/compat'
 import { TransformableInfo } from 'logform'
 import { format } from 'winston'
 

--- a/src/omit-nil-format.ts
+++ b/src/omit-nil-format.ts
@@ -1,4 +1,4 @@
-import { isNil, omitBy } from 'lodash'
+import { isNil, omitBy } from 'es-toolkit/compat'
 import { TransformableInfo } from 'logform'
 import { format } from 'winston'
 

--- a/src/redact-format.ts
+++ b/src/redact-format.ts
@@ -1,0 +1,8 @@
+import { TransformableInfo } from 'logform'
+import { format } from 'winston'
+import { redactValuesWith } from './redact-values'
+
+export const redactFormat = format((info, opts) => {
+  const { paths, redactedValue = '<redacted>' } = opts as { paths: string[]; redactedValue?: string }
+  return redactValuesWith(redactedValue)(info, ...paths) as TransformableInfo
+})

--- a/src/redact-values.ts
+++ b/src/redact-values.ts
@@ -3,7 +3,7 @@ import { cloneDeep, forOwn, get, isNil, isObject, set } from 'es-toolkit/compat'
 /**
  * Recursively replaces values in an object with '<redacted>' for the specified keys. Enumerates arrays and applies the same redaction to elements.
  * @param obj The object to redact
- * @param keys The keys to redact, can be a dot-separated path (uses lodash's get/set).
+ * @param keys The keys to redact, can be a dot-separated path (uses es-toolkit/compat's get/set).
  * Use dot notation to specify more specific keys.
  * Key checks are applied at every level of the object via recursion.
  * @returns A new object with the specified keys redacted
@@ -16,13 +16,9 @@ export const redactValuesWith =
       for (const k of keys) {
         if (!isNil(get(current, k))) set(current, k, redactedValue)
       }
-      forOwn(current, function (value) {
+      // isObject returns true for arrays too, so this recurses into both arrays and plain objects
+      forOwn(current, (value) => {
         if (isObject(value)) redact(value)
-        else if (Array.isArray(value)) {
-          for (const item of value) {
-            if (isObject(item)) redact(item)
-          }
-        }
       })
       return current
     })(cloneDeep(obj))

--- a/src/redact-values.ts
+++ b/src/redact-values.ts
@@ -1,0 +1,31 @@
+import { cloneDeep, forOwn, get, isNil, isObject, set } from 'es-toolkit/compat'
+
+/**
+ * Recursively replaces values in an object with '<redacted>' for the specified keys. Enumerates arrays and applies the same redaction to elements.
+ * @param obj The object to redact
+ * @param keys The keys to redact, can be a dot-separated path (uses lodash's get/set).
+ * Use dot notation to specify more specific keys.
+ * Key checks are applied at every level of the object via recursion.
+ * @returns A new object with the specified keys redacted
+ */
+export const redactValuesWith =
+  (redactedValue: string) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (obj: any, ...keys: string[]) => {
+    return (function redact(current) {
+      for (const k of keys) {
+        if (!isNil(get(current, k))) set(current, k, redactedValue)
+      }
+      forOwn(current, function (value) {
+        if (isObject(value)) redact(value)
+        else if (Array.isArray(value)) {
+          for (const item of value) {
+            if (isObject(item)) redact(item)
+          }
+        }
+      })
+      return current
+    })(cloneDeep(obj))
+  }
+
+export const redactValues = redactValuesWith('<redacted>')

--- a/src/serialize-error-format.spec.ts
+++ b/src/serialize-error-format.spec.ts
@@ -1,0 +1,35 @@
+import { TransformableInfo } from 'logform'
+import { LEVEL } from 'triple-beam'
+import { describe, expect, it } from 'vitest'
+import { serializeErrorFormat } from './serialize-error-format'
+
+const run = (info: Record<string, unknown>) => {
+  const input = { [LEVEL]: 'info', level: 'info', message: '', ...info } as TransformableInfo
+  return serializeErrorFormat().transform(input, {}) as Record<string, unknown>
+}
+
+describe('serializeErrorFormat', () => {
+  it('serializes a top-level nested error', () => {
+    const result = run({ error: new Error('boom') })
+    const error = result.error as { name: string; message: string; stack: string }
+    expect(error.name).toBe('Error')
+    expect(error.message).toBe('boom')
+    expect(error.stack).toBeDefined()
+  })
+
+  it('serializes errors nested inside objects and arrays', () => {
+    const result = run({
+      context: { cause: new Error('deep') },
+      items: [{ err: new Error('in-array') }, 'plain'],
+    })
+    const cause = (result.context as { cause: { message: string } }).cause
+    const arrErr = ((result.items as unknown[])[0] as { err: { message: string } }).err
+    expect(cause.message).toBe('deep')
+    expect(arrErr.message).toBe('in-array')
+  })
+
+  it('leaves non-error values untouched', () => {
+    const result = run({ a: 1, b: 'two', c: { nested: true } })
+    expect(result).toMatchObject({ a: 1, b: 'two', c: { nested: true } })
+  })
+})

--- a/src/serialize-error-format.spec.ts
+++ b/src/serialize-error-format.spec.ts
@@ -32,4 +32,14 @@ describe('serializeErrorFormat', () => {
     const result = run({ a: 1, b: 'two', c: { nested: true } })
     expect(result).toMatchObject({ a: 1, b: 'two', c: { nested: true } })
   })
+
+  it('does not mutate nested caller objects or arrays', () => {
+    const cause = new Error('deep')
+    const arrErr = new Error('in-array')
+    const ctx = { cause }
+    const items = [{ err: arrErr }]
+    run({ context: ctx, items })
+    expect(ctx.cause).toBe(cause)
+    expect(items[0].err).toBe(arrErr)
+  })
 })

--- a/src/serialize-error-format.spec.ts
+++ b/src/serialize-error-format.spec.ts
@@ -1,11 +1,12 @@
 import { TransformableInfo } from 'logform'
 import { LEVEL } from 'triple-beam'
 import { describe, expect, it } from 'vitest'
-import { serializeErrorFormat } from './serialize-error-format'
+import { serializeErrorFormat, SerializeErrorFormatOptions } from './serialize-error-format'
 
-const run = (info: Record<string, unknown>) => {
+const run = (info: Record<string, unknown>, opts?: SerializeErrorFormatOptions) => {
   const input = { [LEVEL]: 'info', level: 'info', message: '', ...info } as TransformableInfo
-  return serializeErrorFormat().transform(input, {}) as Record<string, unknown>
+  const fmt = serializeErrorFormat(opts)
+  return fmt.transform(input, fmt.options) as Record<string, unknown>
 }
 
 describe('serializeErrorFormat', () => {
@@ -41,5 +42,11 @@ describe('serializeErrorFormat', () => {
     run({ context: ctx, items })
     expect(ctx.cause).toBe(cause)
     expect(items[0].err).toBe(arrErr)
+  })
+
+  it('uses the supplied serializer instead of the default', () => {
+    const result = run({ context: { cause: new Error('deep') } }, { serializer: (error) => ({ marker: 'custom', message: error.message }) })
+    const cause = (result.context as { cause: { marker: string; message: string } }).cause
+    expect(cause).toEqual({ marker: 'custom', message: 'deep' })
   })
 })

--- a/src/serialize-error-format.spec.ts
+++ b/src/serialize-error-format.spec.ts
@@ -49,4 +49,28 @@ describe('serializeErrorFormat', () => {
     const cause = (result.context as { cause: { marker: string; message: string } }).cause
     expect(cause).toEqual({ marker: 'custom', message: 'deep' })
   })
+
+  it('replaces nested circular references with [Circular]', () => {
+    const ctx: Record<string, unknown> = { name: 'parent' }
+    ctx.self = ctx
+    const result = run({ ctx })
+    const walked = result.ctx as { name: string; self: unknown }
+    expect(walked.name).toBe('parent')
+    expect(walked.self).toBe('[Circular]')
+  })
+
+  it('replaces a direct cycle on the info object with [Circular]', () => {
+    const input = { [LEVEL]: 'info', level: 'info', message: '' } as TransformableInfo & { self?: unknown }
+    input.self = input
+    const fmt = serializeErrorFormat()
+    const result = fmt.transform(input, fmt.options) as unknown as { self: unknown }
+    expect(result.self).toBe('[Circular]')
+  })
+
+  it('serialises sibling references to the same object independently (no false positive)', () => {
+    const shared = { value: 42 }
+    const result = run({ a: shared, b: shared })
+    expect(result.a).toEqual({ value: 42 })
+    expect(result.b).toEqual({ value: 42 })
+  })
 })

--- a/src/serialize-error-format.ts
+++ b/src/serialize-error-format.ts
@@ -22,18 +22,23 @@ export interface SerializeErrorFormatOptions {
  */
 export const serializeErrorFormat = format((info, opts) => {
   const serializer = (opts as SerializeErrorFormatOptions | undefined)?.serializer ?? serializeError
-  const walk = (value: unknown): unknown => {
+  const walk = (value: unknown, seen: WeakSet<object>): unknown => {
     if (value instanceof Error) return serializer(value)
-    if (Array.isArray(value)) return value.map(walk)
-    if (value && typeof value === 'object') {
+    if (!value || typeof value !== 'object') return value
+    if (seen.has(value)) return '[Circular]'
+    seen.add(value)
+    try {
+      if (Array.isArray(value)) return value.map((v) => walk(v, seen))
       const source = value as Record<string, unknown>
       const out: Record<string, unknown> = {}
-      for (const key of Object.keys(source)) out[key] = walk(source[key])
+      for (const key of Object.keys(source)) out[key] = walk(source[key], seen)
       return out
+    } finally {
+      seen.delete(value)
     }
-    return value
   }
   const record = info as unknown as Record<string, unknown>
-  for (const key of Object.keys(record)) record[key] = walk(record[key])
+  const seen = new WeakSet<object>([record])
+  for (const key of Object.keys(record)) record[key] = walk(record[key], seen)
   return info as TransformableInfo
 })

--- a/src/serialize-error-format.ts
+++ b/src/serialize-error-format.ts
@@ -1,29 +1,38 @@
 import { TransformableInfo } from 'logform'
 import { format } from 'winston'
-import { serializeError } from './serialize-error'
+import { ErrorSerializer, serializeError } from './serialize-error'
 
-const walk = (value: unknown): unknown => {
-  if (value instanceof Error) return serializeError(value)
-  if (Array.isArray(value)) return value.map(walk)
-  if (value && typeof value === 'object') {
-    const source = value as Record<string, unknown>
-    const out: Record<string, unknown> = {}
-    for (const key of Object.keys(source)) out[key] = walk(source[key])
-    return out
-  }
-  return value
+export interface SerializeErrorFormatOptions {
+  /**
+   * Custom serializer used to turn each `Error` instance into a plain object.
+   * Defaults to the library's {@link serializeError} (which delegates to the
+   * [`serialize-error`](https://www.npmjs.com/package/serialize-error) package).
+   */
+  serializer?: ErrorSerializer
 }
 
 /**
  * Walks the log info object, replacing any `Error` instances (including nested ones)
- * with the plain-object result of {@link serializeError} so downstream formats and
+ * with the plain-object result of the configured serializer so downstream formats and
  * transports see JSON-serializable errors with `message` and `stack` intact.
  *
  * Only the top-level `info` object is mutated (to preserve winston's Symbol-keyed
  * routing props); nested objects and arrays are rebuilt, so caller-supplied metadata
  * references are never mutated.
  */
-export const serializeErrorFormat = format((info) => {
+export const serializeErrorFormat = format((info, opts) => {
+  const serializer = (opts as SerializeErrorFormatOptions | undefined)?.serializer ?? serializeError
+  const walk = (value: unknown): unknown => {
+    if (value instanceof Error) return serializer(value)
+    if (Array.isArray(value)) return value.map(walk)
+    if (value && typeof value === 'object') {
+      const source = value as Record<string, unknown>
+      const out: Record<string, unknown> = {}
+      for (const key of Object.keys(source)) out[key] = walk(source[key])
+      return out
+    }
+    return value
+  }
   const record = info as unknown as Record<string, unknown>
   for (const key of Object.keys(record)) record[key] = walk(record[key])
   return info as TransformableInfo

--- a/src/serialize-error-format.ts
+++ b/src/serialize-error-format.ts
@@ -1,0 +1,27 @@
+import { TransformableInfo } from 'logform'
+import { format } from 'winston'
+import { serializeError } from './serialize-error'
+
+const walk = (value: unknown): unknown => {
+  if (value instanceof Error) return serializeError(value)
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) value[i] = walk(value[i])
+    return value
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    for (const key of Object.keys(obj)) obj[key] = walk(obj[key])
+    return obj
+  }
+  return value
+}
+
+/**
+ * Walks the log info object, replacing any `Error` instances (including nested ones)
+ * with the plain-object result of {@link serializeError} so downstream formats and
+ * transports see JSON-serializable errors with `message` and `stack` intact.
+ */
+export const serializeErrorFormat = format((info) => {
+  walk(info)
+  return info as TransformableInfo
+})

--- a/src/serialize-error-format.ts
+++ b/src/serialize-error-format.ts
@@ -4,14 +4,12 @@ import { serializeError } from './serialize-error'
 
 const walk = (value: unknown): unknown => {
   if (value instanceof Error) return serializeError(value)
-  if (Array.isArray(value)) {
-    for (let i = 0; i < value.length; i++) value[i] = walk(value[i])
-    return value
-  }
+  if (Array.isArray(value)) return value.map(walk)
   if (value && typeof value === 'object') {
-    const obj = value as Record<string, unknown>
-    for (const key of Object.keys(obj)) obj[key] = walk(obj[key])
-    return obj
+    const source = value as Record<string, unknown>
+    const out: Record<string, unknown> = {}
+    for (const key of Object.keys(source)) out[key] = walk(source[key])
+    return out
   }
   return value
 }
@@ -20,8 +18,13 @@ const walk = (value: unknown): unknown => {
  * Walks the log info object, replacing any `Error` instances (including nested ones)
  * with the plain-object result of {@link serializeError} so downstream formats and
  * transports see JSON-serializable errors with `message` and `stack` intact.
+ *
+ * Only the top-level `info` object is mutated (to preserve winston's Symbol-keyed
+ * routing props); nested objects and arrays are rebuilt, so caller-supplied metadata
+ * references are never mutated.
  */
 export const serializeErrorFormat = format((info) => {
-  walk(info)
+  const record = info as unknown as Record<string, unknown>
+  for (const key of Object.keys(record)) record[key] = walk(record[key])
   return info as TransformableInfo
 })

--- a/src/serialize-error.spec.ts
+++ b/src/serialize-error.spec.ts
@@ -13,23 +13,34 @@ describe('serializeError', () => {
     expect(stack).toBeDefined()
     expect(stack.split('\n').length).toBeGreaterThan(3)
   })
-  it('can serialize a custom error', () => {
+  it('can serialize a custom error with a cause', () => {
     class CustomError extends Error {
       readonly custom: string
-      constructor(message: string, custom: string) {
-        super(message)
+      constructor(message: string, custom: string, options?: ErrorOptions) {
+        super(message, options)
         this.custom = custom
       }
     }
-    const { message, stack, custom } = JSON.parse(JSON.stringify(serializeError(new CustomError('message', 'custom')))) as {
+    const cause = new Error('cause message')
+    const {
+      message,
+      stack,
+      custom,
+      cause: serializedCause,
+    } = JSON.parse(JSON.stringify(serializeError(new CustomError('message', 'custom', { cause })))) as {
       message: string
       stack: string
       custom: string
+      cause: { name: string; message: string; stack: string }
     }
     expect(message).toMatchInlineSnapshot(`"message"`)
     expect(custom).toMatchInlineSnapshot(`"custom"`)
     expect(stack).toBeDefined()
     expect(stack.split('\n').length).toBeGreaterThan(3)
+    expect(serializedCause.name).toMatchInlineSnapshot(`"Error"`)
+    expect(serializedCause.message).toMatchInlineSnapshot(`"cause message"`)
+    expect(serializedCause.stack).toBeDefined()
+    expect(serializedCause.stack.split('\n').length).toBeGreaterThan(3)
   })
 })
 

--- a/src/serialize-error.spec.ts
+++ b/src/serialize-error.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { serializableErrorReplacer, serializeError } from './serialize-error'
+import { createSerializableErrorReplacer, serializableErrorReplacer, serializeError } from './serialize-error'
 
 describe('serializeError', () => {
   it('message and stack are not enumerable (and not serialized) by default', () => {
@@ -57,5 +57,13 @@ describe('serializableErrorReplacer', () => {
     expect(message).toMatchInlineSnapshot(`"message"`)
     expect(stack).toBeDefined()
     expect(stack.split('\n').length).toBeGreaterThan(3)
+  })
+})
+
+describe('createSerializableErrorReplacer', () => {
+  it('uses the supplied serializer for Error values', () => {
+    const replacer = createSerializableErrorReplacer(() => ({ marker: 'custom' }))
+    const result = JSON.parse(JSON.stringify({ nested: new Error('message') }, replacer)) as { nested: { marker: string } }
+    expect(result.nested.marker).toBe('custom')
   })
 })

--- a/src/serialize-error.ts
+++ b/src/serialize-error.ts
@@ -1,15 +1,17 @@
 import { JsonOptions } from 'logform'
 
 /**
- * Serialize an `Error` object into a plain object so that it can be serialized for logging, including the message and stack
- * - `message` and `stack` are explicitly copied
- * - other enumerable properties copied via `...rest`
+ * Serialize an `Error` object into a plain object so that it can be serialized for logging.
+ * Captures all own properties (including non-enumerable `message`/`stack`) plus `name` from the prototype.
  */
-export const serializeError = ({ message, stack, ...rest }: Error): object => ({
-  message,
-  stack,
-  ...rest,
-})
+export const serializeError = (error: Error): Record<string, unknown> => {
+  const out: Record<string, unknown> = { name: error.name }
+  for (const key of Object.getOwnPropertyNames(error)) {
+    const value = (error as unknown as Record<string, unknown>)[key]
+    out[key] = value instanceof Error ? serializeError(value) : value
+  }
+  return out
+}
 
 /**
  * Replaces values that are `instanceof Error` with the result of `serializeError`

--- a/src/serialize-error.ts
+++ b/src/serialize-error.ts
@@ -1,19 +1,32 @@
 import { JsonOptions } from 'logform'
+import { serializeError as baseSerializeError } from 'serialize-error'
+
+/**
+ * Signature for a function that converts an `Error` instance into a plain, JSON-serializable
+ * representation. Supply your own via `createLogger`'s `errorSerializer` option (or
+ * `serializeErrorFormat({ serializer })`) to customise how errors are rendered across all transports.
+ */
+export type ErrorSerializer = (error: Error) => Record<string, unknown>
 
 /**
  * Serialize an `Error` object into a plain object so that it can be serialized for logging.
- * Captures all own properties (including non-enumerable `message`/`stack`) plus `name` from the prototype.
+ * Delegates to the [`serialize-error`](https://www.npmjs.com/package/serialize-error) package,
+ * which captures `name`, `message`, `stack`, own enumerable properties, and recursively follows
+ * `cause` / nested `Error` values.
  */
-export const serializeError = (error: Error): Record<string, unknown> => {
-  const out: Record<string, unknown> = { name: error.name }
-  for (const key of Object.getOwnPropertyNames(error)) {
-    const value = (error as unknown as Record<string, unknown>)[key]
-    out[key] = value instanceof Error ? serializeError(value) : value
-  }
-  return out
-}
+export const serializeError: ErrorSerializer = (error) => baseSerializeError(error) as Record<string, unknown>
 
 /**
- * Replaces values that are `instanceof Error` with the result of `serializeError`
+ * Builds a JSON replacer that substitutes `Error` instances with the output of the supplied
+ * `serializer` (defaults to {@link serializeError}). The `serializableErrorReplacer` export is
+ * the default instance, pre-bound to {@link serializeError}.
  */
-export const serializableErrorReplacer: JsonOptions['replacer'] = (_key, value) => (value instanceof Error ? serializeError(value) : value)
+export const createSerializableErrorReplacer =
+  (serializer: ErrorSerializer = serializeError): JsonOptions['replacer'] =>
+  (_key, value) =>
+    value instanceof Error ? serializer(value) : value
+
+/**
+ * Replaces values that are `instanceof Error` with the result of {@link serializeError}.
+ */
+export const serializableErrorReplacer: JsonOptions['replacer'] = createSerializableErrorReplacer()


### PR DESCRIPTION
# 1 Problem: ESM output does not work, only CJS works

The [prior PR adding dual ESM + CJS output does not actually work](https://github.com/MakerXStudio/node-winston/pull/132) for ESM due to the continued use of CJS only lodash.
Lodash does not have a single dual output library, lodash-es is ESM only.

We cannot just replace lodash with a simple function because the omit-by-dot-notation keys functionality is important and is used for omit logging config.

## Solution

Swap to es-toolkit which provides modern dual ESM + CJS output with 100% lodash compatibility.

## Implementation notes

- Bumping to the next major version, since consumers will no longer get "full lodash" installed automatically via the peer dep.
- Keeping use of es-toolkit as a peer dep vs hard dep, since:
    - we don't want to force version numbers or constantly update this package past vulnerabilities
    - we expect ESM consumers may prefer opting in to control and use the version of es-toolkit at the consumer level (no loss)

# 2 Problem: formats (e.g. for `omitPaths` applied to console transport)
... however OTEL does not receive log data at the transport level, so this would not apply for OTEL received log data

- Refactor application of formats to the logger level so that `omitPaths` and other format-based options apply equally to all log output regardless of transport

# 3 Add functionality we normally use:
- New `redactPaths` / `redactedValue` options replace values at dot-notation paths across every transport. Also available as the standalone `redactFormat`, and the `redactValues` / `redactValuesWith` helpers for direct use.
- New `flatten` / `flattenReplacer` options serialise every top-level value on the log info to a JSON string, producing a flat `{ key: string }` shape suited to OTEL + Azure Log Analytics and other scalar-only aggregators..
- Errors nested inside structured metadata are now fully serialised at the logger level (not just the Console transport) via the new `serializeErrorFormat`. It walks the whole info object — including nested objects and arrays — replacing every `Error` with a plain object that carries `name`, `message` and `stack`.
- Add `audit` log level by default
- `createLogger` is now generic over the level map. When you pass `loggerOptions.levels`, the returned logger's method signatures narrow to your level keys (`logger.fatal(...)` becomes valid, `logger.audit` becomes a type error).