### PR TITLE
Replace winston deep import with main-entry import for ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,13 +166,12 @@ Every format used by `createLogger` is also exported for direct use with your ow
 Direct usage example:
 
 ```ts
-import { format, createLogger } from 'winston'
-import { Console } from 'winston/lib/winston/transports'
+import { format, createLogger, transports } from 'winston'
 import { redactFormat, serializeErrorFormat } from '@makerx/node-winston'
 
 const logger = createLogger({
   format: format.combine(serializeErrorFormat(), redactFormat({ paths: ['user.email'] })),
-  transports: [new Console({ format: format.json() })],
+  transports: [new transports.Console({ format: format.json() })],
 })
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/node-winston",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/node-winston",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/node-winston",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "private": false,
   "description": "A set of winston formats, console transport and logger creation functions",
   "author": "MakerX",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
 import { format, Format } from 'logform'
-import { createLogger as winstonCreateLogger, Logger as WinstonLogger, LoggerOptions, LeveledLogMethod, addColors } from 'winston'
+import {
+  createLogger as winstonCreateLogger,
+  Logger as WinstonLogger,
+  LoggerOptions,
+  LeveledLogMethod,
+  addColors,
+  transports,
+} from 'winston'
 import * as Transport from 'winston-transport'
-import { Console, ConsoleTransportOptions } from 'winston/lib/winston/transports'
 import { jsonStringifyValuesFormat } from './json-stringify-values-format'
 import { omitFormat } from './omit-format'
 import { omitNilFormat } from './omit-nil-format'
@@ -9,6 +15,13 @@ import { prettyConsoleFormat } from './pretty-console-format'
 import { redactFormat } from './redact-format'
 import { createSerializableErrorReplacer, ErrorSerializer, serializeError } from './serialize-error'
 import { serializeErrorFormat } from './serialize-error-format'
+
+// `winston/lib/winston/transports` is a CJS deep import that can't be consumed from ESM: it's a
+// directory import, and even with a `/index.js` suffix its named exports are defined via
+// `Object.defineProperty(exports, 'X', { get() {...} })` which cjs-module-lexer doesn't expose
+// as ESM named bindings. Go through winston's main entry instead.
+const { Console } = transports
+type ConsoleTransportOptions = transports.ConsoleTransportOptions
 
 export * from './json-stringify-values'
 export * from './json-stringify-values-format'


### PR DESCRIPTION
## Summary

Fixes a runtime `SyntaxError` in the v2 beta ESM build when consumers import from `@makerx/node-winston` under pure ESM (e.g. Vitest, Node 22+ with `"type": "module"`):

```
SyntaxError: The requested module 'winston/lib/winston/transports' does not provide an export named 'Console'
```

The offending line was:

```ts
import { Console, ConsoleTransportOptions } from 'winston/lib/winston/transports'
```

That worked under CJS `require()` but breaks in ESM for two reasons (verified against winston 3.19.0):

1. **Directory import.** Node ESM requires the explicit `/index.js` suffix; otherwise it throws `ERR_UNSUPPORTED_DIR_IMPORT`.
2. **Lazy-getter named exports aren't statically detectable.** Even with the suffix, `winston/lib/winston/transports/index.js` defines `Console` via `Object.defineProperty(exports, 'Console', { get() { return require('./console') } })`. `cjs-module-lexer` (what Node's ESM→CJS interop uses) doesn't expose this shape as an ESM named binding, so `import { Console }` fails.

Fix: go through winston's main entry, which does `exports.transports = require('./winston/transports')` — a form cjs-module-lexer handles cleanly. `ConsoleTransportOptions` is now sourced via the `transports` namespace (type-only).

Also updated the direct-usage example in the README to match.

## Test plan

- [x] `npm run check-types` passes
- [x] `npm run lint` passes
- [x] `npm run test` — all 34 tests pass
- [x] `npm run build` — verified `dist/index.mjs` no longer references `winston/lib/winston/transports`
- [x] Swapped the built package into a consumer ESM project (vitest) — the original `SyntaxError: Named export 'Console' not found` is gone and the suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)