### PR TITLE
Support custom audit level rewrite for OTEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,25 @@ New functionality:
 
 Formats are applied in two layers:
 
-- **Logger-level** (applied to all transports, in order): `serializeErrorFormat` → `omitFormat` (if `omitPaths`) → `redactFormat` (if `redactPaths`) → `loggerOptions.format` (if supplied) → `jsonStringifyValuesFormat` (if `flatten`; always last so it captures every prior transformation).
+- **Logger-level** (applied to all transports, in order): `serializeErrorFormat` → `mapAuditLevelForOtel` (if enabled) → `omitFormat` (if `omitPaths`) → `redactFormat` (if `redactPaths`) → `loggerOptions.format` (if supplied) → `jsonStringifyValuesFormat` (if `flatten`; always last so it captures every prior transformation).
 - **Console transport** (applied to Console output only): `omitNilFormat` → any `consoleFormats` → either `prettyConsoleFormat` (when `consoleFormat: 'pretty'`) or `timestamp` + `json` (when `consoleFormat: 'json'`).
 
 ### Options
 
-| Option            | Type                      | Description                                                                                                                                                                                                                                                                                    |
-| ----------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `consoleFormat`   | `'json' \| 'pretty'`      | Output format for the Console transport. `json` (default) for deployed environments, `pretty` for colourised YAML during local development.                                                                                                                                                    |
-| `consoleOptions`  | `ConsoleTransportOptions` | Options forwarded to the Console transport (e.g. `silent`, per-transport `level`). The `format` property is managed by this library.                                                                                                                                                           |
-| `consoleFormats`  | `Format[]`                | Extra formats appended to the Console transport's format chain, before the final `json`/`pretty` step. Applies to the Console transport only.                                                                                                                                                  |
-| `transports`      | `Transport[]`             | Additional winston transports attached alongside the Console transport.                                                                                                                                                                                                                        |
-| `omitPaths`       | `string[]`                | Dot-notation paths to remove from every log entry. Applied at the logger level, so affects all transports.                                                                                                                                                                                     |
-| `redactPaths`     | `string[]`                | Dot-notation paths whose values are replaced with `redactedValue`. Applied at the logger level, so affects all transports.                                                                                                                                                                     |
-| `redactedValue`   | `string`                  | Replacement value used by `redactPaths`. Defaults to `'<redacted>'`.                                                                                                                                                                                                                           |
-| `flatten`         | `boolean`                 | When `true`, serialises every top-level value on the log info to a JSON string, producing a flat `{ key: string }` shape for transports that expect scalar values (e.g. OTEL + Azure Log Analytics).                                                                                           |
-| `flattenReplacer` | `(key, value) => any`     | Optional `JSON.stringify` replacer used when `flatten` serialises each top-level value.                                                                                                                                                                                                        |
-| `errorSerializer` | `ErrorSerializer`         | Custom serializer applied to every `Error` instance at the logger level (via `serializeErrorFormat`) and as the Console transport's `format.json` replacer. Defaults to the library's `serializeError`, which delegates to [`serialize-error`](https://www.npmjs.com/package/serialize-error). |
-| `loggerOptions`   | `LoggerOptions`           | Winston logger options (e.g. `level`, `defaultMeta`). A `format` supplied here is appended after the library's logger-level formats but still runs before `flatten` when enabled.                                                                                                              |
+| Option                                  | Type                      | Description                                                                                                                                                                                                                                                                                                          |
+| --------------------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `consoleFormat`                         | `'json' \| 'pretty'`      | Output format for the Console transport. `json` (default) for deployed environments, `pretty` for colourised YAML during local development.                                                                                                                                                                          |
+| `consoleOptions`                        | `ConsoleTransportOptions` | Options forwarded to the Console transport (e.g. `silent`, per-transport `level`). The `format` property is managed by this library.                                                                                                                                                                                 |
+| `consoleFormats`                        | `Format[]`                | Extra formats appended to the Console transport's format chain, before the final `json`/`pretty` step. Applies to the Console transport only.                                                                                                                                                                        |
+| `transports`                            | `Transport[]`             | Additional winston transports attached alongside the Console transport.                                                                                                                                                                                                                                              |
+| `omitPaths`                             | `string[]`                | Dot-notation paths to remove from every log entry. Applied at the logger level, so affects all transports.                                                                                                                                                                                                           |
+| `redactPaths`                           | `string[]`                | Dot-notation paths whose values are replaced with `redactedValue`. Applied at the logger level, so affects all transports.                                                                                                                                                                                           |
+| `redactedValue`                         | `string`                  | Replacement value used by `redactPaths`. Defaults to `'<redacted>'`.                                                                                                                                                                                                                                                 |
+| `flatten`                               | `boolean`                 | When `true`, serialises every top-level value on the log info to a JSON string, producing a flat `{ key: string }` shape for transports that expect scalar values (e.g. OTEL + Azure Log Analytics).                                                                                                                 |
+| `flattenReplacer`                       | `(key, value) => any`     | Optional `JSON.stringify` replacer used when `flatten` serialises each top-level value.                                                                                                                                                                                                                              |
+| `errorSerializer`                       | `ErrorSerializer`         | Custom serializer applied to every `Error` instance at the logger level (via `serializeErrorFormat`) and as the Console transport's `format.json` replacer. Defaults to the library's `serializeError`, which delegates to [`serialize-error`](https://www.npmjs.com/package/serialize-error).                       |
+| `mapAuditLevelForOtel`                  | `boolean`                 | When `true`, rewrites the triple-beam `LEVEL` from `audit` to `info` and copies the original onto `logLevel` for OTEL compatibility. See [Shipping the audit level via OpenTelemetry](#shipping-the-audit-level-via-opentelemetry).                                                                                  |
+| `loggerOptions`                         | `LoggerOptions`           | Winston logger options (e.g. `level`, `defaultMeta`). A `format` supplied here is appended after the library's logger-level formats but still runs before `flatten` when enabled.                                                                                                                                    |
 
 ### Log levels
 
@@ -81,6 +82,22 @@ addColors({ fatal: 'red', error: 'red', info: 'green', trace: 'cyan' })
 
 logger.fatal('process is exiting') // typed; logger.audit would be a type error
 ```
+
+### Shipping the audit level via OpenTelemetry
+
+[`@opentelemetry/instrumentation-winston`](https://www.npmjs.com/package/@opentelemetry/instrumentation-winston) auto-installs [`@opentelemetry/winston-transport`](https://www.npmjs.com/package/@opentelemetry/winston-transport), which derives OTEL's `severityText` / `severityNumber` from Winston's triple-beam `LEVEL` symbol and strips the string `level` property before building attributes. OTEL's log spec only defines a fixed severity enumeration (trace/debug/info/warn/error/fatal), so Winston's custom `audit` level arrives with `severityNumber: undefined` and no queryable record of the original level. This is most visible on Azure Monitor / Log Analytics (which ignores records without a mapped severity), but affects any OTEL backend that relies on the spec-defined severity.
+
+Set `mapAuditLevelForOtel: true` to opt in:
+
+```ts
+const logger = createLogger({
+  mapAuditLevelForOtel: true,
+})
+```
+
+The format rewrites the triple-beam `LEVEL` symbol from `audit` to `info` (so OTEL maps the record onto `info` severity) and copies the original level onto a `logLevel` property (so it survives as an OTEL attribute — e.g. queryable as `customDimensions.logLevel == "audit"` in Azure Log Analytics). The string `info.level` is left as `audit` for other transports — so local Console JSON output still shows `"level": "audit"`.
+
+**Caveat:** the `LEVEL` symbol also drives transport-level filtering, so a logger, console, or transport explicitly set to `level: 'audit'` would silently drop these records after the rewrite (`info` is more verbose than `audit`). `createLogger` detects this combination and throws at construction — use `'info'` (or a more verbose level) instead. Only enable this option when shipping logs via OTEL — typically a deployed-environment concern.
 
 ### Example: environment-driven configuration
 
@@ -154,14 +171,15 @@ const logger = createLogger({
 
 Every format used by `createLogger` is also exported for direct use with your own winston setup.
 
-| Format                      | Purpose                                                                                                                                                                |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `serializeErrorFormat`      | Walks the log info (including nested objects and arrays) and replaces `Error` instances with plain objects that include the normally non-enumerable `message`/`stack`. |
-| `omitFormat`                | Removes fields by dot-notation path via [es-toolkit's compat `omit`](https://es-toolkit.dev/reference/compat/object/omit.html) (lodash-compatible).                    |
-| `omitNilFormat`             | Removes top-level `null` or `undefined` values.                                                                                                                        |
-| `redactFormat`              | Recursively replaces values at the given paths with `redactedValue` (default `'<redacted>'`).                                                                          |
-| `jsonStringifyValuesFormat` | Serialises every top-level value to a JSON string, producing a flat `{ key: string }` shape. Accepts an optional `replacer`.                                           |
-| `prettyConsoleFormat`       | Applies `colorize` and `timestamp`, then renders logs as coloured YAML using [`yamlify-object`](https://www.npmjs.com/package/yamlify-object).                         |
+| Format                                  | Purpose                                                                                                                                                                |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serializeErrorFormat`                  | Walks the log info (including nested objects and arrays) and replaces `Error` instances with plain objects that include the normally non-enumerable `message`/`stack`. |
+| `omitFormat`                            | Removes fields by dot-notation path via [es-toolkit's compat `omit`](https://es-toolkit.dev/reference/compat/object/omit.html) (lodash-compatible).                    |
+| `omitNilFormat`                         | Removes top-level `null` or `undefined` values.                                                                                                                        |
+| `redactFormat`                          | Recursively replaces values at the given paths with `redactedValue` (default `'<redacted>'`).                                                                          |
+| `jsonStringifyValuesFormat`             | Serialises every top-level value to a JSON string, producing a flat `{ key: string }` shape. Accepts an optional `replacer`.                                           |
+| `prettyConsoleFormat`                   | Applies `colorize` and `timestamp`, then renders logs as coloured YAML using [`yamlify-object`](https://www.npmjs.com/package/yamlify-object).                         |
+| `mapAuditLevelForOtel`                  | Rewrites the triple-beam `LEVEL` symbol from `audit` to `info` and copies the original onto `logLevel` so custom levels survive OTEL's severity enumeration.           |
 
 Direct usage example:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/node-winston",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/node-winston",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/node-winston",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "private": false,
   "description": "A set of winston formats, console transport and logger creation functions",
   "author": "MakerX",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,3 +1,4 @@
+import { LEVEL } from 'triple-beam'
 import { format } from 'winston'
 import TransportStream from 'winston-transport'
 import { describe, expect, it } from 'vitest'
@@ -216,6 +217,77 @@ describe('createLogger flatten', () => {
     })
     logger.info('hello')
     expect((transport.logs[0] as { injected: unknown }).injected).toBe('{"a":1}')
+  })
+})
+
+describe('createLogger mapAuditLevelForOtel', () => {
+  it('rewrites the LEVEL symbol from audit to info, preserves the original on logLevel, and leaves the string level alone', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [transport],
+      mapAuditLevelForOtel: true,
+    })
+    logger.audit('audit-event', { actor: 'user-1' })
+    const info = transport.logs[0] as Record<string | symbol, unknown>
+    expect(info[LEVEL]).toBe('info')
+    expect(info.level).toBe('audit')
+    expect(info.logLevel).toBe('audit')
+    expect(info.actor).toBe('user-1')
+  })
+
+  it('leaves non-audit levels untouched but still records logLevel', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({
+      consoleOptions: { silent: true },
+      transports: [transport],
+      mapAuditLevelForOtel: true,
+    })
+    logger.warn('heads-up')
+    const info = transport.logs[0] as Record<string | symbol, unknown>
+    expect(info.level).toBe('warn')
+    expect(info[LEVEL]).toBe('warn')
+    expect(info.logLevel).toBe('warn')
+  })
+
+  it('is opt-in — when disabled, audit records keep their level and no logLevel is added', () => {
+    const transport = new InMemoryTransport({})
+    const logger = createLogger({ consoleOptions: { silent: true }, transports: [transport] })
+    logger.audit('audit-event')
+    const info = transport.logs[0] as Record<string | symbol, unknown>
+    expect(info.level).toBe('audit')
+    expect(info[LEVEL]).toBe('audit')
+    expect(info.logLevel).toBeUndefined()
+  })
+
+  it('throws when loggerOptions.level is audit (records would be silently dropped after rewrite)', () => {
+    expect(() =>
+      createLogger({
+        mapAuditLevelForOtel: true,
+        consoleOptions: { silent: true },
+        loggerOptions: { level: 'audit' },
+      }),
+    ).toThrow(/loggerOptions\.level/)
+  })
+
+  it('throws when consoleOptions.level is audit', () => {
+    expect(() =>
+      createLogger({
+        mapAuditLevelForOtel: true,
+        consoleOptions: { level: 'audit', silent: true },
+      }),
+    ).toThrow(/consoleOptions\.level/)
+  })
+
+  it('throws when any supplied transport has level audit', () => {
+    const transport = new InMemoryTransport({ level: 'audit' })
+    expect(() =>
+      createLogger({
+        mapAuditLevelForOtel: true,
+        consoleOptions: { silent: true },
+        transports: [transport],
+      }),
+    ).toThrow(/transports\[0\]\.level/)
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { prettyConsoleFormat } from './pretty-console-format'
 import { redactFormat } from './redact-format'
 import { createSerializableErrorReplacer, ErrorSerializer, serializeError } from './serialize-error'
 import { serializeErrorFormat } from './serialize-error-format'
+import { mapAuditLevelForOtel } from './map-audit-level-for-otel'
 
 // `winston/lib/winston/transports` is a CJS deep import that can't be consumed from ESM: it's a
 // directory import, and even with a `/index.js` suffix its named exports are defined via
@@ -32,6 +33,7 @@ export * from './redact-format'
 export * from './redact-values'
 export * from './serialize-error'
 export * from './serialize-error-format'
+export * from './map-audit-level-for-otel'
 
 // winstonjs' default levels have debug and verbose reversed, which is confusing and causes filtering issues with Seq,
 // CloudWatch etc (given they assume Verbose/Trace should be the lowest/noisiest log level).
@@ -129,6 +131,16 @@ export interface CreateLoggerOptions {
   flattenReplacer?: (this: any, key: string, value: any) => any
 
   /**
+   * When `true`, prepends `mapAuditLevelForOtel` to the logger-level format chain. Rewrites the
+   * triple-beam `LEVEL` symbol from `audit` to `info` so OTEL maps the record onto a known severity
+   * tier, and copies the original level onto a `logLevel` property so it survives as an OTEL attribute
+   * (the OTEL winston-transport strips the string `level`). Enable when shipping logs via OTEL — most
+   * visibly for Azure Monitor / Log Analytics, but applies to any OTEL backend that relies on the
+   * spec-defined severity.
+   */
+  mapAuditLevelForOtel?: boolean
+
+  /**
    * Custom serializer used whenever an `Error` instance is encountered, both by the logger-level
    * `serializeErrorFormat` (walks the full info tree) and by the Console transport's
    * `format.json` replacer (safety net for errors that slip through). Defaults to the library's
@@ -177,10 +189,36 @@ export function createLogger<const L extends Record<string, number>>(
 export function createLogger(options: CreateLoggerOptions): Logger
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createLogger(options: CreateLoggerOptions): any {
-  const { omitPaths, redactPaths, redactedValue = '<redacted>', flatten, flattenReplacer, errorSerializer } = options
+  const {
+    omitPaths,
+    redactPaths,
+    redactedValue = '<redacted>',
+    flatten,
+    flattenReplacer,
+    errorSerializer,
+    mapAuditLevelForOtel: mapAuditForOtel,
+  } = options
 
   // register default colours on first use of the default levels so `colorize` / pretty output works
   if (!options.loggerOptions?.levels) registerDefaultColors()
+
+  // Guard against silent audit-record loss: the format rewrites the LEVEL symbol from 'audit' to 'info',
+  // which the filter on any transport set to level:'audit' would then drop (info is more verbose than audit).
+  if (mapAuditForOtel) {
+    const misconfigured: string[] = []
+    if (options.loggerOptions?.level === 'audit') misconfigured.push('loggerOptions.level')
+    if (options.consoleOptions?.level === 'audit') misconfigured.push('consoleOptions.level')
+    options.transports?.forEach((t, i) => {
+      if (t.level === 'audit') misconfigured.push(`transports[${i}].level`)
+    })
+    if (misconfigured.length > 0) {
+      throw new Error(
+        `mapAuditLevelForOtel rewrites the triple-beam LEVEL symbol from 'audit' to 'info', ` +
+          `which would be dropped by the 'audit'-level filter on ${misconfigured.join(', ')}. ` +
+          `Use 'info' (or a more verbose level) instead.`,
+      )
+    }
+  }
 
   // aggregate transports
   const consoleTransport = createConsoleTransport(options)
@@ -189,6 +227,7 @@ export function createLogger(options: CreateLoggerOptions): any {
 
   // logger-level formats apply to all transports
   const loggerFormats: Format[] = [serializeErrorFormat({ serializer: errorSerializer })]
+  if (mapAuditForOtel) loggerFormats.push(mapAuditLevelForOtel())
   if (omitPaths) loggerFormats.push(omitFormat({ paths: omitPaths }))
   if (redactPaths) loggerFormats.push(redactFormat({ paths: redactPaths, redactedValue }))
   if (options.loggerOptions?.format) loggerFormats.push(options.loggerOptions.format)

--- a/src/map-audit-level-for-otel.ts
+++ b/src/map-audit-level-for-otel.ts
@@ -1,0 +1,32 @@
+import { LEVEL } from 'triple-beam'
+import { format } from 'winston'
+
+/**
+ * OTEL's log spec defines a fixed severity enumeration (trace/debug/info/warn/error/fatal).
+ * `@opentelemetry/winston-transport` (auto-installed by `@opentelemetry/instrumentation-winston`)
+ * derives `severityText` / `severityNumber` from Winston's triple-beam `LEVEL` symbol and strips
+ * the string `level` property before building attributes — so Winston's custom `audit` level
+ * arrives at any OTEL backend with `severityNumber: undefined` and no queryable record of the
+ * original level. This is most visible on Azure Monitor / Log Analytics (which ignores records
+ * without a mapped severity), but applies to any OTEL backend that relies on the spec-defined
+ * severity.
+ *
+ * This format:
+ * - rewrites `info[LEVEL]` from `audit` to `info` so OTEL maps to a known severity tier
+ * - copies the original level onto `logLevel` on every record so it survives as an OTEL
+ *   attribute (e.g. queryable as `customDimensions.logLevel == "audit"` in Azure Log Analytics)
+ *
+ * The string `info.level` is left as-is — it's only consumed by other winston transports (e.g.
+ * our Console transport's JSON output), so leaving it alone keeps local output readable.
+ *
+ * Caveat: because the `LEVEL` symbol also drives transport-level filtering, a logger/transport
+ * explicitly set to `level: 'audit'` would drop these records after rewrite (info is more
+ * verbose than audit). `createLogger` guards against that by throwing when the option is
+ * enabled alongside an `audit`-level logger/console/transport; when using the format
+ * standalone, apply the same discipline. Only enable this when shipping logs via OTEL.
+ */
+export const mapAuditLevelForOtel = format((info) => {
+  info.logLevel = info.level
+  if (info.level === 'audit') info[LEVEL] = 'info'
+  return info
+})


### PR DESCRIPTION
When using the winston OTEL transport instrumentation, if you use the custom audit log level, it needs to be re-written to avoid OTEL sending `severityLevel: undefined` to the OTEL endpoint.

This PR adds the song-and-dance we usually do in each app via a format, via a simple option, with docs. 