### PR TITLE
Add CallbackTransport class for promise-callback-based custom transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ const logger = createLogger({
 
 In-flight dispatches are tracked internally and drained via `Promise.allSettled` on `close()`, and any rejection from the handler is routed to the supplied `logError` so a failing endpoint can't recurse back through this transport.
 
+`CallbackTransport` filters on the string `info.level` rather than the triple-beam `LEVEL` symbol, so the `level` option remains accurate when paired with `mapAuditLevelForOtel` (which rewrites the symbol but leaves the string untouched). For the same reason it sidesteps the `mapAuditLevelForOtel` + `level: 'audit'` guard in `createLogger` — the option is intercepted by the transport rather than passed down to the base `winston-transport` class.
+
 ## Formats
 
 Every format used by `createLogger` is also exported for direct use with your own winston setup.

--- a/README.md
+++ b/README.md
@@ -238,6 +238,26 @@ A few things worth calling out:
 - Inject an error sink (`logError`) rather than logging dispatch failures via the same logger this transport is attached to — otherwise a failing endpoint produces an audit record that produces another failing dispatch.
 - Override `close()` and `Promise.allSettled` the in-flight set so a failing dispatch doesn't reject the drain. Winston calls `close` from `logger.close()` / `logger.end()`, so transports get a chance to flush before exit.
 
+#### `CallbackTransport`
+
+For the common case where the only thing you'd customise is the dispatch itself, the library exports `CallbackTransport` — a ready-made subclass that wraps the boilerplate above. Construct it with a promise-returning `LogHandler` (receives a `TransformedInfo` — the same `{ level, message, meta }` shape `extractTransformableInfo` returns) and a `LogError` sink for dispatch failures, and pass any standard winston-transport options (e.g. `level`) through the third argument:
+
+```ts
+import { CallbackTransport, createLogger } from '@makerx/node-winston'
+
+const logger = createLogger({
+  transports: [
+    new CallbackTransport(
+      ({ level, message, meta }) => sendToAuditEndpoint({ level, message, ...meta }),
+      (message, ...args) => logger.error(message, ...args),
+      { level: 'audit' },
+    ),
+  ],
+})
+```
+
+In-flight dispatches are tracked internally and drained via `Promise.allSettled` on `close()`, and any rejection from the handler is routed to the supplied `logError` so a failing endpoint can't recurse back through this transport.
+
 ## Formats
 
 Every format used by `createLogger` is also exported for direct use with your own winston setup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/node-winston",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/node-winston",
-      "version": "2.0.0-beta.7",
+      "version": "2.0.0-beta.8",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/node-winston",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "private": false,
   "description": "A set of winston formats, console transport and logger creation functions",
   "author": "MakerX",

--- a/src/callback-transport.spec.ts
+++ b/src/callback-transport.spec.ts
@@ -1,0 +1,93 @@
+import { type TransformableInfo } from 'logform'
+import { LEVEL } from 'triple-beam'
+import { describe, expect, it, vi } from 'vitest'
+import { CallbackTransport } from './callback-transport'
+import { type TransformedInfo } from './utils'
+
+const buildInfo = (level: string, message: string, meta: Record<string, unknown> = {}): TransformableInfo =>
+  ({ [LEVEL]: level, level, message, ...meta }) as TransformableInfo
+
+describe('CallbackTransport', () => {
+  it('forwards each record to the handler with extracted info', async () => {
+    const received: TransformedInfo[] = []
+    const transport = new CallbackTransport(
+      async (info) => {
+        received.push(info)
+      },
+      () => {},
+    )
+
+    transport.log!(buildInfo('info', 'hello', { user: 'u-1' }), () => {})
+    transport.log!(buildInfo('audit', 'audit-event', { actor: 'a-1' }), () => {})
+
+    await transport.close!()
+
+    expect(received).toHaveLength(2)
+    expect(received[0]).toEqual({ level: 'info', message: 'hello', meta: { user: 'u-1' } })
+    expect(received[1]).toEqual({ level: 'audit', message: 'audit-event', meta: { actor: 'a-1' } })
+  })
+
+  it('routes handler rejections to the logError sink', async () => {
+    const failure = new Error('endpoint down')
+    const logError = vi.fn()
+    const transport = new CallbackTransport(() => Promise.reject(failure), logError)
+
+    transport.log!(buildInfo('info', 'boom'), () => {})
+
+    await transport.close!()
+
+    expect(logError).toHaveBeenCalledTimes(1)
+    expect(logError).toHaveBeenCalledWith('Error in CallbackTransport:', { error: failure })
+  })
+
+  it('calls next exactly once per record without awaiting the handler', () => {
+    let resolveHandler!: () => void
+    const handlerPromise = new Promise<void>((resolve) => {
+      resolveHandler = resolve
+    })
+    const transport = new CallbackTransport(
+      () => handlerPromise,
+      () => {},
+    )
+    const next = vi.fn()
+
+    transport.log!(buildInfo('info', 'pending'), next)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    resolveHandler()
+  })
+
+  it('drains in-flight dispatches on close', async () => {
+    let resolveHandler!: () => void
+    const handlerPromise = new Promise<void>((resolve) => {
+      resolveHandler = resolve
+    })
+    let handlerSettled = false
+    const transport = new CallbackTransport(
+      () =>
+        handlerPromise.then(() => {
+          handlerSettled = true
+        }),
+      () => {},
+    )
+
+    transport.log!(buildInfo('info', 'pending'), () => {})
+
+    const closing = transport.close!()
+    expect(handlerSettled).toBe(false)
+
+    resolveHandler()
+    await closing
+
+    expect(handlerSettled).toBe(true)
+  })
+
+  it('forwards winston-transport options to the base class', () => {
+    const transport = new CallbackTransport(
+      async () => {},
+      () => {},
+      { level: 'audit' },
+    )
+    expect(transport.level).toBe('audit')
+  })
+})

--- a/src/callback-transport.spec.ts
+++ b/src/callback-transport.spec.ts
@@ -2,10 +2,16 @@ import { type TransformableInfo } from 'logform'
 import { LEVEL } from 'triple-beam'
 import { describe, expect, it, vi } from 'vitest'
 import { CallbackTransport } from './callback-transport'
+import { defaultLevels } from './index'
 import { type TransformedInfo } from './utils'
 
 const buildInfo = (level: string, message: string, meta: Record<string, unknown> = {}): TransformableInfo =>
   ({ [LEVEL]: level, level, message, ...meta }) as TransformableInfo
+
+const attachLevels = (transport: CallbackTransport, levels: Record<string, number> = defaultLevels): CallbackTransport => {
+  ;(transport as unknown as { levels: Record<string, number> }).levels = levels
+  return transport
+}
 
 describe('CallbackTransport', () => {
   it('forwards each record to the handler with extracted info', async () => {
@@ -82,12 +88,87 @@ describe('CallbackTransport', () => {
     expect(handlerSettled).toBe(true)
   })
 
-  it('forwards winston-transport options to the base class', () => {
+  it('filters records below the configured level using the string info.level', async () => {
+    const received: TransformedInfo[] = []
+    const transport = attachLevels(
+      new CallbackTransport(
+        async (info) => {
+          received.push(info)
+        },
+        () => {},
+        { level: 'audit' },
+      ),
+    )
+
+    transport.log!(buildInfo('error', 'error-event'), () => {})
+    transport.log!(buildInfo('audit', 'audit-event'), () => {})
+    transport.log!(buildInfo('info', 'info-event'), () => {})
+    transport.log!(buildInfo('verbose', 'verbose-event'), () => {})
+
+    await transport.close!()
+
+    expect(received.map((info) => info.message)).toEqual(['error-event', 'audit-event'])
+  })
+
+  it('filters on the string info.level even when LEVEL symbol has been rewritten', async () => {
+    const received: TransformedInfo[] = []
+    const transport = attachLevels(
+      new CallbackTransport(
+        async (info) => {
+          received.push(info)
+        },
+        () => {},
+        { level: 'audit' },
+      ),
+    )
+
+    // Simulate `mapAuditLevelForOtel`: LEVEL symbol rewritten from 'audit' to 'info', string
+    // `level` left untouched. winston-transport's stock filter would drop this; ours must not.
+    const audit = { [LEVEL]: 'info', level: 'audit', message: 'audit-event' } as TransformableInfo
+
+    transport.log!(audit, () => {})
+
+    await transport.close!()
+
+    expect(received.map((info) => info.message)).toEqual(['audit-event'])
+  })
+
+  it('does not expose the configured level on the underlying winston Transport', () => {
     const transport = new CallbackTransport(
       async () => {},
       () => {},
       { level: 'audit' },
     )
-    expect(transport.level).toBe('audit')
+    // We intercept `level` in our constructor so `createLogger`'s mapAuditLevelForOtel guard
+    // (which reads `transport.level`) does not trip when the transport is configured for audit.
+    expect(transport.level).toBeUndefined()
+  })
+
+  it('routes audit records through createLogger with mapAuditLevelForOtel and level: audit', async () => {
+    const { createLogger } = await import('./index')
+    const received: TransformedInfo[] = []
+    const transport = new CallbackTransport(
+      async (info) => {
+        received.push(info)
+      },
+      () => {},
+      { level: 'audit' },
+    )
+
+    // Without the level interception this combination would either throw at construction
+    // (createLogger guard) or silently drop the record (LEVEL rewrite + symbol-based filter).
+    const logger = createLogger({
+      consoleOptions: { silent: true },
+      mapAuditLevelForOtel: true,
+      transports: [transport],
+    })
+
+    logger.audit('audit-event', { actor: 'a-1' })
+    logger.info('info-event')
+    logger.verbose('verbose-event')
+
+    await transport.close!()
+
+    expect(received.map((info) => info.message)).toEqual(['audit-event'])
   })
 })

--- a/src/callback-transport.ts
+++ b/src/callback-transport.ts
@@ -19,12 +19,20 @@ export type LogHandler = (info: TransformedInfo) => Promise<unknown>
 /**
  * Custom winston transport that forwards each log record to a promise-returning callback, with
  * built-in tracking of in-flight dispatches so `close()` can drain them on shutdown. Construct
- * with the dispatch handler and an error sink for dispatch failures; filter records via
- * winston-transport's standard `level` option (or by inspecting the info inside the handler).
+ * with the dispatch handler, an error sink for dispatch failures, and (optionally) the standard
+ * winston-transport options.
+ *
+ * Unlike the stock winston-transport `level` filter — which compares the triple-beam `LEVEL`
+ * symbol — this transport filters on the string `info.level` instead. That makes the `level`
+ * option safe to combine with `mapAuditLevelForOtel`, which rewrites the `LEVEL` symbol but
+ * leaves `info.level` alone. The option is intercepted in the constructor (not forwarded to
+ * the base class), so `createLogger`'s `mapAuditLevelForOtel` + `level: 'audit'` guard does not
+ * trip on it.
  *
  * @example
  * ```ts
  * const logger = createLogger({
+ *   mapAuditLevelForOtel: true,
  *   transports: [
  *     new CallbackTransport(
  *       ({ level, message, meta }) => sendToAuditEndpoint({ level, message, ...meta }),
@@ -37,17 +45,28 @@ export type LogHandler = (info: TransformedInfo) => Promise<unknown>
  */
 export class CallbackTransport extends Transport {
   private readonly inFlight = new Set<Promise<unknown>>()
+  private readonly minLevel: string | undefined
 
   constructor(
     private readonly handler: LogHandler,
     private readonly logError: LogError,
     options?: Transport.TransportStreamOptions,
   ) {
-    super(options)
+    const { level, ...rest } = options ?? {}
+    super(rest)
+    this.minLevel = level
   }
 
   override log(info: TransformableInfo, next: () => void): void {
     const transformed = extractTransformableInfo(info)
+
+    // `levels` is set on the transport by winston when it's piped from a logger; the stock
+    // `winston-transport` type definitions don't declare it, so we read it via cast.
+    const levels = (this as unknown as { levels?: Record<string, number> }).levels
+    if (this.minLevel !== undefined && levels && levels[this.minLevel] < levels[transformed.level]) {
+      next()
+      return
+    }
 
     const promise = Promise.resolve()
       .then(() => this.handler(transformed))

--- a/src/callback-transport.ts
+++ b/src/callback-transport.ts
@@ -1,0 +1,65 @@
+import { type TransformableInfo } from 'logform'
+import Transport from 'winston-transport'
+import { extractTransformableInfo, type TransformedInfo } from './utils'
+
+/**
+ * Sink for dispatch failures inside {@link CallbackTransport}. Pass a function that logs to a
+ * different logger / channel than the one this transport is attached to — otherwise a failing
+ * dispatch produces a record that produces another failing dispatch.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type LogError = (message: string, ...args: any[]) => void
+
+/**
+ * Promise-returning callback invoked for every record forwarded to a {@link CallbackTransport}.
+ * Receives the {@link TransformedInfo} produced by {@link extractTransformableInfo}.
+ */
+export type LogHandler = (info: TransformedInfo) => Promise<unknown>
+
+/**
+ * Custom winston transport that forwards each log record to a promise-returning callback, with
+ * built-in tracking of in-flight dispatches so `close()` can drain them on shutdown. Construct
+ * with the dispatch handler and an error sink for dispatch failures; filter records via
+ * winston-transport's standard `level` option (or by inspecting the info inside the handler).
+ *
+ * @example
+ * ```ts
+ * const logger = createLogger({
+ *   transports: [
+ *     new CallbackTransport(
+ *       ({ level, message, meta }) => sendToAuditEndpoint({ level, message, ...meta }),
+ *       (message, ...args) => logger.error(message, ...args),
+ *       { level: 'audit' },
+ *     ),
+ *   ],
+ * })
+ * ```
+ */
+export class CallbackTransport extends Transport {
+  private readonly inFlight = new Set<Promise<unknown>>()
+
+  constructor(
+    private readonly handler: LogHandler,
+    private readonly logError: LogError,
+    options?: Transport.TransportStreamOptions,
+  ) {
+    super(options)
+  }
+
+  override log(info: TransformableInfo, next: () => void): void {
+    const transformed = extractTransformableInfo(info)
+
+    const promise = Promise.resolve()
+      .then(() => this.handler(transformed))
+      .catch((error) => this.logError('Error in CallbackTransport:', { error }))
+      .finally(() => this.inFlight.delete(promise))
+
+    this.inFlight.add(promise)
+
+    next()
+  }
+
+  override async close(): Promise<void> {
+    await Promise.allSettled([...this.inFlight])
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { mapAuditLevelForOtel } from './map-audit-level-for-otel'
 const { Console } = transports
 type ConsoleTransportOptions = transports.ConsoleTransportOptions
 
+export * from './callback-transport'
 export * from './json-stringify-values'
 export * from './json-stringify-values-format'
 export * from './omit-format'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,14 @@
 import { type TransformableInfo } from 'logform'
 import { LEVEL, SPLAT } from 'triple-beam'
 
-export function extractTransformableInfo(info: TransformableInfo): { level: string; message: string; meta: Record<string, unknown> } {
+/**
+ * Plain shape of a winston `TransformableInfo` after the `triple-beam` symbols (`LEVEL`, `SPLAT`)
+ * have been stripped and `level` / `message` split out from the remaining metadata. Returned by
+ * {@link extractTransformableInfo}.
+ */
+export type TransformedInfo = { level: string; message: string; meta: Record<string, unknown> }
+
+export function extractTransformableInfo(info: TransformableInfo): TransformedInfo {
   const { [LEVEL]: _, [SPLAT]: __, level, message, ...meta } = info
   return { level, message: message as string, meta }
 }


### PR DESCRIPTION
Wraps the boilerplate from the README's custom-transport recipe into a
ready-made `CallbackTransport` subclass: construct with a promise-returning
`LogHandler` (receives a `TransformedInfo`) and a `LogError` sink, and the
transport tracks in-flight dispatches and drains them in `close()`. Also
exports the `TransformedInfo` type returned by `extractTransformableInfo`
so consumers can type the handler argument directly.